### PR TITLE
NETOBSERV-1499 Github config for CLI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- Fill-in description here -->
+
+## Dependencies
+
+<!-- List here any related PRs with links, that need to be pulled also for testing -->
+n/a
+
+## Checklist
+
+If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.
+
+* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
+* [ ] Does this PR require product documentation?
+  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
+* [ ] Does this PR require a product release notes entry?
+  * [ ] If so, fill in "Release Note Text" in the JIRA.
+* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
+  * [ ] If so, make sure it is described in the JIRA ticket.
+* QE requirements (check 1 from the list):
+  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
+  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
+  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Breaking changes 🛠
+      labels:
+        - breaking-change
+    - title: Non-breaking changes
+      labels:
+        - "*"

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,15 @@
+name: greetings
+
+on: [issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Congratulations for contributing your first netobserv-cli issue'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,32 @@
+name: pull request checks
+
+on:
+  pull_request:
+    branches: ['*']
+
+jobs:
+  build-test:
+    name: Build, lint, test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.21', '1.22']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Install make
+      run: sudo apt -y install make
+    - name: run build
+      run: make build && git diff --exit-code
+    - name: run unit tests
+      run: make test coverage-report
+    - name: Report coverage
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        files: ./cover.out
+        flags: unittests
+        fail_ci_if_error: true

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,0 +1,66 @@
+name: Build and push to quay.io
+on:
+  push:
+    branches: [ main, release-*, workflow-test ]
+
+env:
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le s390x
+  WF_VERSION: ${{ github.ref_name }}
+
+jobs:
+  push-image:
+    name: push image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.21']
+    steps:
+      - name: install make
+        run: sudo apt-get install make
+      - name: set up go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: docker login to quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.WF_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_SECRET }}
+          registry: quay.io
+      - name: get short sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: build and push manifest with images
+        run: |
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
+          if [[ "main" == "$WF_VERSION" ]]; then
+            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
+          fi
+
+  codecov:
+    name: Codecov upload
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.21']
+    steps:
+    - name: install make
+      run: sudo apt-get install make
+    - name: set up go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
+    - name: checkout
+      uses: actions/checkout@v3
+    - name: Test
+      run: make test coverage-report
+    - name: Report coverage
+      uses: codecov/codecov-action@v2.1.0
+      with:
+        files: ./cover.out
+        flags: unittests
+        fail_ci_if_error: false

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -1,0 +1,59 @@
+name: Build and push PR image to quay.io
+on:
+  pull_request_target:
+    types: [labeled]
+
+env:
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: network-observability-cli
+  WF_ORG: netobserv
+
+jobs:
+  push-pr-image:
+    if: ${{ github.event.label.name == 'ok-to-test' }}
+    name: push PR image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.21']
+    steps:
+      - name: install make
+        run: sudo apt-get install make
+      - name: set up go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: docker login to quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.WF_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_SECRET }}
+          registry: quay.io
+      - name: get short sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: build and push manifest with images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `New image:
+            ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }}
+
+            It will expire after two weeks.
+
+            To use this build, update your oc commands using:
+            \`\`\`bash
+            USER=netobserv VERSION=${{ env.short_sha }} make oc-commands
+            \`\`\`
+            `
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: release to quay.io
+on:
+  push:
+    tags: [v*]
+
+env:
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le s390x
+
+jobs:
+  push-image:
+    name: push image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.21']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: validate tag
+        run: |
+          tag=`git describe --exact-match --tags 2> /dev/null`
+          if [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+              echo "$tag is a valid release tag"
+              set -e
+              echo "tag=$tag" >> $GITHUB_ENV
+          else
+              echo "$tag is NOT a valid release tag"
+              exit 1
+          fi
+      - name: install make
+        run: sudo apt-get install make
+      - name: set up go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: docker login to quay.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.WF_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_SECRET }}
+          registry: quay.io
+      - name: build and push manifest with images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images

--- a/.github/workflows/rm-ok-to-test.yaml
+++ b/.github/workflows/rm-ok-to-test.yaml
@@ -1,0 +1,15 @@
+name: Remove ok-to-test
+on:
+  pull_request_target:
+    types: [synchronize,reopened]
+
+jobs:
+  rm-ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    name: Remove ok-to-test
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: ok-to-test
+          fail_on_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 output
 tmp
+cover.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+linters:
+  enable:
+    - errcheck
+    - errorlint
+    - cyclop
+    - errname
+    - exhaustive
+    - exportloopref
+    - gocritic
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unused
+linters-settings:
+  stylecheck:
+    go: "1.21"
+  gocritic:
+    enabled-checks:
+      - hugeParam
+      - rangeExprCopy
+      - rangeValCopy
+      - indexAlloc
+      - deprecatedComment
+  cyclop:
+    max-complexity: 150 # TODO: reduce that to 20

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- jotak
+- jpinsonneau
+- OlivierCazade
+- eranra
+- KalmanMeth
+- ronensc
+- msherif1234
+options: {}
+reviewers:
+- jotak
+- jpinsonneau
+- OlivierCazade
+- stleerh
+- eranra
+- KalmanMeth
+- ronensc
+- msherif1234

--- a/cmd/flow-capture.go
+++ b/cmd/flow-capture.go
@@ -49,7 +49,7 @@ var (
 	enrichement        = []string{resourceEnrichment}
 )
 
-func runFlowCapture(cmd *cobra.Command, args []string) {
+func runFlowCapture(_ *cobra.Command, _ []string) {
 	go scanner()
 
 	wg := sync.WaitGroup{}

--- a/cmd/packet-capture.go
+++ b/cmd/packet-capture.go
@@ -37,7 +37,7 @@ var results = []PcapResult{}
 // Setting Snapshot length to 0 sets it to maximum packet size
 var snapshotlen uint32
 
-func runPacketCapture(cmd *cobra.Command, args []string) {
+func runPacketCapture(_ *cobra.Command, _ []string) {
 	go packetCaptureScanner()
 
 	wg := sync.WaitGroup{}

--- a/oc/oc-netobserv-flows
+++ b/oc/oc-netobserv-flows
@@ -12,6 +12,9 @@ else
   filter=$1
 fi
 
+# CLI image to use
+img="quay.io/jpinsonn/network-observability-cli:dev"
+
 trap cleanup EXIT
 
 setup flows $filter
@@ -20,7 +23,7 @@ echo "\nRunning network-observability-cli get-flows... "
 oc run \
   -n netobserv-cli \
   collector \
-  --image=quay.io/jpinsonn/network-observability-cli:dev \
+  --image=$img\
   --image-pull-policy='Always' \
   --restart='Never' \
   --command -- sleep infinity

--- a/oc/oc-netobserv-packets
+++ b/oc/oc-netobserv-packets
@@ -13,6 +13,9 @@ else
   filter=$1
 fi
 
+# CLI image to use
+img="quay.io/jpinsonn/network-observability-cli:dev"
+
 trap cleanup EXIT
 
 setup packets $filter
@@ -21,7 +24,7 @@ echo "\nRunning network-observability-cli get-packets... "
 oc run \
   -n netobserv-cli \
   collector \
-  --image=quay.io/jpinsonn/network-observability-cli:dev \
+  --image=$img \
   --image-pull-policy='Always' \
   --restart='Never' \
   --command -- sleep infinity

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -14,6 +14,14 @@ sed -i -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/oc-netobserv-flows
 sed -i -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/oc-netobserv-packets
 sed -i -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/oc-netobserv-cleanup
 
+if [ -z "$2" ]; then
+  echo "image not provided, keeping current ones"
+else 
+  echo "updating CLI images to $2"
+  sed -i "/img=/c\img=\"$2\"" ./tmp/oc-netobserv-flows
+  sed -i "/img=/c\img=\"$2\"" ./tmp/oc-netobserv-packets
+fi
+
 rm ./tmp/functions.sh
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
## Description

Adding github files + miscs and allow injecting image from Make target

Also see prow configs: https://github.com/openshift/release/pull/50198

## Dependencies

Based on https://github.com/netobserv/network-observability-cli/pull/3, merge it first and rebase when dependencies are updated

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
