### PR TITLE
Remove bash trace and manage unbound var

### DIFF
--- a/oc/oc-netobserv-flows
+++ b/oc/oc-netobserv-flows
@@ -2,11 +2,14 @@
 source "${BASH_SOURCE%/*}/network-observability-cli-resources/functions.sh"
 
 # interface filter such as 'br-ex'
-filter=$1
+filter=""
 
-if [ -z "$filter" ]
+if [ -z "${1:-}" ]
 then
-  filter=""
+  echo "Filters not set"
+else
+  echo "Filters set as $1"
+  filter=$1
 fi
 
 trap cleanup EXIT

--- a/oc/oc-netobserv-packets
+++ b/oc/oc-netobserv-packets
@@ -2,12 +2,15 @@
 source "${BASH_SOURCE%/*}/network-observability-cli-resources/functions.sh"
 
 # pcap filter such as 'tcp,80'
-filter=$1
+filter=""
 
-if [ -z "$filter" ]
+if [ -z "${1:-}" ]
 then
   echo "Specify a valid filter as first argument such as 'oc get-packets tcp,80'"
   exit 1
+else
+  echo "Filters set as $1"
+  filter=$1
 fi
 
 trap cleanup EXIT

--- a/res/functions.sh
+++ b/res/functions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 function setup {
   echo "Setting up... "


### PR DESCRIPTION
Since `functions.sh` is called from oc commands, we need to adapt the scripts to ensure variables are bound.

Else the scripts simply crash when filters are not set:
```
$ oc netobserv packets
/usr/local/bin/oc-netobserv-packets: line 5: $1: unbound variable
```

Also removed trace since it makes difficult to read the custom messages that are supposed to guide you.