### PR TITLE
install golangci-lint only if its not installed and update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ prepare:
 .PHONY: prereqs
 prereqs: ## Test if prerequisites are met, and installing missing dependencies
 	@echo "### Test if prerequisites are met, and installing missing dependencies"
+ifeq (, $(shell which golangci-lint))
 	GOFLAGS="" go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+endif
 
 .PHONY: vendors
 vendors: ## Refresh vendors directory.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This will also copy resources and oc commands to the `build` directory.
 Simply run the following command to start capturing flows:
 
 ```bash
-./build/oc-netobserv-flows
+./oc/oc-netobserv-flows
 ```
 
 ![flows](./img/flow-table.png)
@@ -65,13 +65,13 @@ To stop capturing press Ctrl-C.
 PCAP generated files are compatible with Wireshark
 
 ```bash
-./build/oc-netobserv-packets <filters>
+./oc/oc-netobserv-packets <filters>
 ```
 
 For example:
 
 ```bash
-./build/oc-netobserv-packets "tcp,8080"
+./oc/oc-netobserv-packets "tcp,8080"
 ```
 
 ![packets](./img/packet-table.png)
@@ -84,7 +84,7 @@ To stop capturing press Ctrl-C.
 The `cleanup` function will automatically remove the eBPF programs when the CLI exits. However you may need to run it manually if an error occurs.
 
 ```bash
-./build/oc-netobserv-cleanup
+./oc/oc-netobserv-cleanup
 ```
 
 ## Extending OpenShift CLI with plugin


### PR DESCRIPTION
## Description

install golangci-lint only if its not installed 

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
