### PR TITLE
remove chown and use WORKDIR as workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,12 @@ COPY .mk/ .mk/
 
 # Build
 RUN GOARCH=$TARGETARCH make compile
-# Prepare output dir
-RUN mkdir -p output
 
-# Create final image from ubi + built binary
+# Create final image from ubi + built binary + output folder
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi:9.3
+# hack to get output folder created with access
+WORKDIR /output
 WORKDIR /
 COPY --from=builder /opt/app-root/build .
-COPY --from=builder /opt/app-root/output /output
-RUN chown 65532 output
-USER 65532:65532
 
 ENTRYPOINT ["/network-observability-cli"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This will also copy resources and oc commands to the `build` directory.
 
 To build your own images of CLI, run the following command replacing `USER` and `VERSION` accordingly:
 ```bash
-USER=netobserv VERSION=dev make images
+USER=netobserv VERSION=main make images
 ```
 
 ## Run
@@ -59,7 +59,7 @@ USER=netobserv VERSION=dev make images
 Run the following command to start capturing flows, replacing `USER`, `VERSION` and `COMMAND_ARGS` accordingly:
 
 ```bash
-USER=netobserv VERSION=dev COMMAND_ARGS=br-ex make flows
+USER=netobserv VERSION=main COMMAND_ARGS=br-ex make flows
 ```
 
 ![flows](./img/flow-table.png)
@@ -122,7 +122,7 @@ or `dbeaver`:
 Run the following command to start capturing packets, replacing `USER`, `VERSION` and `COMMAND_ARGS` accordingly:
 
 ```bash
-USER=netobserv VERSION=dev COMMAND_ARGS=tcp,80 make packets
+USER=netobserv VERSION=main COMMAND_ARGS=tcp,80 make packets
 ```
 
 ![packets](./img/packet-table.png)


### PR DESCRIPTION
alternative of https://github.com/netobserv/network-observability-cli/pull/19