### PR TITLE
NETOBSERV-1498 add testing to table displays

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,8 +28,9 @@ jobs:
       run: go mod vendor
     - name: Report coverage
       if: ${{ matrix.go == '1.21' }}
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v4
       with:
         files: ./cover.out
         flags: unittests
         fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Test
       run: make test coverage-report
     - name: Report coverage
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v4
       with:
         files: ./cover.out
         flags: unittests

--- a/cmd/flow_capture_test.go
+++ b/cmd/flow_capture_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlowTableRefreshDelay(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	manageFlowsDisplay([]byte(`{"TimeFlowEndMs": 1709741962017}`))
+
+	out := buf.String()
+	assert.Empty(t, out)
+}
+
+func TestFlowTableDefaultDisplay(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	// add 1s to current time to avoid maxRefreshRate limit
+	tickTime()
+
+	manageFlowsDisplay([]byte(sampleFlow))
+
+	// get table output as string
+	rows := strings.Split(buf.String(), "\n")
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcName                                        SrcType   DstName                                        DstType   DropBytes     DropPackets   DropState             DropCause                                 DnsId   DnsLatency  DnsRCode  DnsErrno  RTT     `, rows[0])
+	assert.Equal(t, `17:25:28.703000   src-pod                                        Pod       dst-pod                                        Pod       32B           1             TCP_INVALID_STATE     SKB_DROP_REASON_TCP_INVALID_SEQUENCE      31319   1ms         NoError   0         10µs    `, rows[1])
+	assert.Equal(t, `----------------  ---------------------------------------------  --------  ---------------------------------------------  --------  ------------  ------------  --------------------  ----------------------------------------  ------  ------      ------    ------    ------  `, rows[2])
+	assert.Empty(t, rows[3])
+}
+
+func TestFlowTableMultipleFlows(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	// set display to standard without enrichment
+	display = []string{standardDisplay}
+	enrichement = []string{noEnrichment}
+
+	// set time and bytes per flow
+	flowTime := 1704063600000
+	bytes := 1
+
+	// sent 40 flows to the table
+	for i := 0; i < 40; i++ {
+		// add 1s to current time to avoid maxRefreshRate limit
+		tickTime()
+		// reset buffer
+		buf.Reset()
+
+		// update time and bytes for next flow
+		flowTime = flowTime + 1000
+		bytes = bytes + 1000
+
+		// add flow to table
+		manageFlowsDisplay([]byte(fmt.Sprintf(`{
+			"AgentIP":"10.0.1.1",
+			"Bytes":%d,
+			"DstAddr":"10.0.0.6",
+			"Packets":1,
+			"SrcAddr":"10.0.0.5",
+			"TimeFlowEndMs":%d
+		}`, bytes, flowTime)))
+	}
+
+	// get table output as string
+	rows := strings.Split(buf.String(), "\n")
+	// table must display only 38 rows (35 flows + header + footer + empty line)
+	assert.Equal(t, 38, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  Dir         Interfaces        Proto   Dscp      Bytes   Packets  `, rows[0])
+	// first flow is the 6th one that came to the display
+	assert.Equal(t, `00:00:06.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       6KB     1        `, rows[1])
+	assert.Equal(t, `00:00:07.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       7KB     1        `, rows[2])
+	assert.Equal(t, `00:00:08.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       8KB     1        `, rows[3])
+	assert.Equal(t, `00:00:09.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       9KB     1        `, rows[4])
+	assert.Equal(t, `00:00:10.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       10KB    1        `, rows[5])
+	// last flow is the 40th one
+	assert.Equal(t, `00:00:40.000000   10.0.0.5                                  n/a      10.0.0.6                                  n/a      n/a         n/a               n/a     n/a       40KB    1        `, rows[35])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ----------  ----------------  ------  --------  ------  ------   `, rows[36])
+	assert.Empty(t, rows[37])
+
+}
+
+func TestFlowTableAdvancedDisplay(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	// getRows function cleanup everything and redraw table with sample flow
+	getRows := func(d []string, e []string) []string {
+		// prepare display options
+		display = d
+		enrichement = e
+
+		// clear filters and previous flows
+		regexes = []string{}
+		lastFlows = []config.GenericMap{}
+		buf.Reset()
+
+		// add one second to time and draw table
+		tickTime()
+		manageFlowsDisplay([]byte(sampleFlow))
+
+		// get table output per rows
+		return strings.Split(buf.String(), "\n")
+	}
+
+	// set display without enrichment
+	rows := getRows([]string{pktDropDisplay, dnsDisplay, rttDisplay}, []string{noEnrichment})
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  DropBytes     DropPackets   DropState             DropCause                                 DnsId   DnsLatency  DnsRCode  DnsErrno  RTT     `, rows[0])
+	assert.Equal(t, `17:25:28.703000   10.128.0.29                               1234     10.129.0.26                               5678     32B           1             TCP_INVALID_STATE     SKB_DROP_REASON_TCP_INVALID_SEQUENCE      31319   1ms         NoError   0         10µs    `, rows[1])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ------------  ------------  --------------------  ----------------------------------------  ------  ------      ------    ------    ------  `, rows[2])
+	assert.Empty(t, rows[3])
+
+	// set display to standard
+	rows = getRows([]string{standardDisplay}, []string{noEnrichment})
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  Dir         Interfaces        Proto   Dscp      Bytes   Packets  `, rows[0])
+	assert.Equal(t, `17:25:28.703000   10.128.0.29                               1234     10.129.0.26                               5678     Ingress     f18b970c2ce8fdd   TCP     Standard  456B    5        `, rows[1])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ----------  ----------------  ------  --------  ------  ------   `, rows[2])
+	assert.Empty(t, rows[3])
+
+	// set display to pktDrop
+	rows = getRows([]string{pktDropDisplay}, []string{noEnrichment})
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  DropBytes     DropPackets   DropState             DropCause                                 `, rows[0])
+	assert.Equal(t, `17:25:28.703000   10.128.0.29                               1234     10.129.0.26                               5678     32B           1             TCP_INVALID_STATE     SKB_DROP_REASON_TCP_INVALID_SEQUENCE      `, rows[1])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ------------  ------------  --------------------  ----------------------------------------  `, rows[2])
+	assert.Empty(t, rows[3])
+
+	// set display to DNS
+	rows = getRows([]string{dnsDisplay}, []string{noEnrichment})
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  DnsId   DnsLatency  DnsRCode  DnsErrno  `, rows[0])
+	assert.Equal(t, `17:25:28.703000   10.128.0.29                               1234     10.129.0.26                               5678     31319   1ms         NoError   0         `, rows[1])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ------  ------      ------    ------    `, rows[2])
+	assert.Empty(t, rows[3])
+
+	// set display to RTT
+	rows = getRows([]string{rttDisplay}, []string{noEnrichment})
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Time              SrcAddr                                   SrcPort  DstAddr                                   DstPort  RTT     `, rows[0])
+	assert.Equal(t, `17:25:28.703000   10.128.0.29                               1234     10.129.0.26                               5678     10µs    `, rows[1])
+	assert.Equal(t, `----------------  ----------------------------------------  ------   ----------------------------------------  ------   ------  `, rows[2])
+	assert.Empty(t, rows[3])
+}

--- a/cmd/map_format.go
+++ b/cmd/map_format.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/jpillora/sizestr"
@@ -386,6 +388,13 @@ func toDSCP(genericMap config.GenericMap, fieldName string) interface{} {
 func toText(genericMap config.GenericMap, fieldName string) interface{} {
 	v, ok := genericMap[fieldName]
 	if ok {
+		if reflect.TypeOf(v).Kind() == reflect.Slice {
+			arr := make([]string, len(v.([]interface{})))
+			for i, v := range v.([]interface{}) {
+				arr[i] = v.(string)
+			}
+			return strings.Join(arr, ",")
+		}
 		return v
 	}
 	return emptyText
@@ -445,6 +454,8 @@ func ToTableRow(genericMap config.GenericMap, cols []string) []interface{} {
 			row = append(row, toText(genericMap, "PktDropLatestDropCause"))
 		case "DnsLatency":
 			row = append(row, toDuration(genericMap, "DnsLatencyMs", time.Millisecond))
+		case "DnsRCode":
+			row = append(row, toText(genericMap, "DnsFlagsResponseCode"))
 		case "RTT":
 			row = append(row, toDuration(genericMap, "TimeFlowRttNs", time.Nanosecond))
 		default:

--- a/cmd/map_format_test.go
+++ b/cmd/map_format_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatTableRows(t *testing.T) {
+	var flow config.GenericMap
+	err := json.Unmarshal([]byte(sampleFlow), &flow)
+	assert.Nil(t, err)
+
+	tableRow := ToTableRow(flow, []string{"Time", "SrcAddr", "DstAddr", "Bytes", "Packets", "Dir", "Proto", "Dscp"})
+	assert.Equal(t, []interface{}{"17:25:28.703000", "10.128.0.29", "10.129.0.26", "456B", float64(5), "Ingress", "TCP", "Standard"}, tableRow)
+
+	tableRow = ToTableRow(flow, []string{"SrcZone", "DstZone", "SrcHostName", "DstHostName", "SrcOwnerName", "DstOwnerName", "SrcName", "DstName"})
+	assert.Equal(t, []interface{}{"us-east-1d", "us-west-1a", "ip-XX-X-X-XX1.ec2.internal", "ip-XX-X-X-XX2.ec2.internal", "my-deployment", "my-statefulset", "src-pod", "dst-pod"}, tableRow)
+
+	tableRow = ToTableRow(flow, []string{"DropBytes", "DropPackets", "DropState", "DropCause", "DnsLatency", "DnsRCode", "RTT"})
+	assert.Equal(t, []interface{}{"32B", float64(1), "TCP_INVALID_STATE", "SKB_DROP_REASON_TCP_INVALID_SEQUENCE", "1ms", "NoError", "10µs"}, tableRow)
+}

--- a/cmd/packet_capture_test.go
+++ b/cmd/packet_capture_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketTableRefreshDelay(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	managePacketsDisplay(PcapResult{Name: "test", ByteCount: 0, PacketCount: 0})
+
+	out := buf.String()
+	assert.Empty(t, out)
+}
+
+func TestPacketTableDefaultDisplay(t *testing.T) {
+	setup()
+
+	// set output buffer to draw table
+	buf := bytes.Buffer{}
+	setOutputBuffer(&buf)
+
+	getRows := func(name string, byteCount int64, packetCount int64) []string {
+		// add 1s to current time to avoid maxRefreshRate limit
+		tickTime()
+		buf.Reset()
+
+		// add bytes and packets to table
+		managePacketsDisplay(PcapResult{Name: name, ByteCount: byteCount, PacketCount: packetCount})
+
+		// get table output per rows
+		return strings.Split(buf.String(), "\n")
+	}
+
+	// start with 123 bytes and 1 packet
+	rows := getRows("test", 123, 1)
+
+	assert.Equal(t, 3, len(rows))
+	assert.Equal(t, `Name          Packets          Bytes          `, rows[0])
+	assert.Equal(t, `test          1                123B           `, rows[1])
+	assert.Empty(t, rows[2])
+
+	// add 10k bytes and 99 packets
+	rows = getRows("test", 10000, 99)
+
+	assert.Equal(t, 3, len(rows))
+	assert.Equal(t, `Name          Packets          Bytes           `, rows[0])
+	assert.Equal(t, `test          100              10.1KB          `, rows[1])
+	assert.Empty(t, rows[2])
+
+	// add another source
+	rows = getRows("test2", 1, 1)
+
+	assert.Equal(t, 4, len(rows))
+	assert.Equal(t, `Name           Packets          Bytes           `, rows[0])
+	assert.Equal(t, `test           100              10.1KB          `, rows[1])
+	assert.Equal(t, `test2          1                1B              `, rows[2])
+	assert.Empty(t, rows[3])
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
 	"sync"
 	"time"
 
@@ -19,9 +21,19 @@ var (
 	nodes    []string
 	filter   string
 
-	startupTime = time.Now()
+	currentTime = func() time.Time {
+		return time.Now()
+	}
+	startupTime = currentTime()
 	lastRefresh = startupTime
 	mutex       = sync.Mutex{}
+
+	resetTerminal = func() {
+		// clear terminal to render table properly
+		fmt.Print("\x1bc")
+		// no wrap
+		fmt.Print("\033[?7l")
+	}
 
 	rootCmd = &cobra.Command{
 		Use:   "network-observability-cli",
@@ -30,6 +42,8 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 		},
 	}
+
+	outputBuffer *bytes.Buffer
 )
 
 // Execute executes the root command.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -88,6 +88,14 @@ func setup() {
 }
 
 func resetTime() {
+	// set timezone to Paris time for all tests
+	loc, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		log.Fatal(err)
+	}
+	time.Local = loc
+
+	// reset all timers
 	currentTime = originalTime
 	lastRefresh = startupTime
 	simulatedTime = startupTime

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// this fake flow represent various possible values for every features
+	sampleFlow = `{
+		"AgentIP":"10.0.1.2",
+		"Bytes":456,
+		"DnsErrno":0,
+		"DnsFlags":34176,
+		"DnsFlagsResponseCode":"NoError",
+		"DnsId":31319,
+		"DnsLatencyMs":1,
+		"Dscp":0,
+		"DstAddr":"10.129.0.26",
+		"DstK8S_HostIP":"10.0.1.2",
+		"DstK8S_HostName":"ip-XX-X-X-XX2.ec2.internal",
+		"DstK8S_Name":"dst-pod",
+		"DstK8S_Namespace":"second-namespace",
+		"DstK8S_OwnerName":"my-statefulset",
+		"DstK8S_OwnerType":"StatefulSet",
+		"DstK8S_Type":"Pod",
+		"DstK8S_Zone":"us-west-1a",
+		"DstMac":"0A:58:0A:81:00:1A",
+		"DstPort":5678,
+		"Duplicate":false,
+		"Etype":2048,
+		"Flags":16,
+		"FlowDirection":0,
+		"IfDirections":[1],
+		"Interfaces":["f18b970c2ce8fdd"],
+		"K8S_FlowLayer":"infra",
+		"Packets":5,
+		"PktDropBytes":32,
+		"PktDropLatestDropCause":"SKB_DROP_REASON_TCP_INVALID_SEQUENCE",
+		"PktDropLatestFlags":16,
+		"PktDropLatestState":"TCP_INVALID_STATE",
+		"PktDropPackets":1,
+		"Proto":6,
+		"SrcAddr":"10.128.0.29",
+		"SrcK8S_HostIP":"10.0.1.1",
+		"SrcK8S_HostName":"ip-XX-X-X-XX1.ec2.internal",
+		"SrcK8S_Name":"src-pod",
+		"SrcK8S_Namespace":"first-namespace",
+		"SrcK8S_OwnerName":"my-deployment",
+		"SrcK8S_OwnerType":"Deployment",
+		"SrcK8S_Type":"Pod",
+		"SrcK8S_Zone":"us-east-1d",
+		"SrcMac":"0A:58:0A:81:00:01",
+		"SrcPort":1234,
+		"TimeFlowEndMs":1709742328703,
+		"TimeFlowRttNs":10000,
+		"TimeFlowStartMs":1709742328660,
+		"TimeReceived":1709742330
+	}`
+)
+
+var (
+	originalTime  = currentTime
+	simulatedTime = startupTime
+)
+
+func TestDefaultArguments(t *testing.T) {
+	assert.Equal(t, "info", logLevel)
+	assert.Equal(t, []int{9999}, ports)
+	assert.Equal(t, []string{""}, nodes)
+	assert.Empty(t, filter)
+}
+
+func setup() {
+	// reset time to startup time
+	resetTime()
+
+	// clear filters and previous flows
+	regexes = []string{}
+	lastFlows = []config.GenericMap{}
+
+	// clear packets
+	packets = []PcapResult{}
+}
+
+func resetTime() {
+	currentTime = originalTime
+	lastRefresh = startupTime
+	simulatedTime = startupTime
+}
+
+func tickTime() {
+	currentTime = func() time.Time {
+		simulatedTime = simulatedTime.Add(1 * time.Second)
+		return simulatedTime
+	}
+}
+
+func setOutputBuffer(buff *bytes.Buffer) {
+	// set output buffer for testing
+	outputBuffer = buff
+
+	// avoid terminal clear
+	resetTerminal = func() {}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/rodaine/table v1.1.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -87,7 +88,6 @@ require (
 	github.com/segmentio/kafka-go v0.4.47 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/vishvananda/netlink v1.1.0 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/vmware/go-ipfix v0.9.0 // indirect


### PR DESCRIPTION
## Description

Add testing to table displays
- Flows
- Packets

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
