### PR TITLE
NETOBSERV-1609: parse flow filter configs and use it to update manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
 KREW_PLUGIN ?=false
 
 GOLANGCI_LINT_VERSION = v1.54.2
+YQ_VERSION = v4.43.1
 
 # build a single arch target provided as argument
 define build_target
@@ -82,6 +83,9 @@ prereqs: ## Test if prerequisites are met, and installing missing dependencies
 	@echo "### Test if prerequisites are met, and installing missing dependencies"
 ifeq (, $(shell which golangci-lint))
 	GOFLAGS="" go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+endif
+ifeq (, $(shell which yq))
+	GOFLAGS="" go install github.com/mikefarah/yq/v4@${YQ_VERSION}
 endif
 
 .PHONY: vendors

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -34,13 +34,8 @@ case "$1" in
     echo "Netobserv CLI version $version"
     exit 0 ;;
 "flows")
-    if [ -z "${2:-}" ]
-    then
-      echo "Filters not set"
-    else
-      echo "Filters set as $2"
-      filter=$2
-    fi
+    shift # remove first argument
+    filter="$*"
     # run flows command
     command="flows" ;;
 "packets")

--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -30,17 +30,45 @@ spec:
           - name: LOG_LEVEL
             value: trace
           - name: INTERFACES
-            value: "{{FLOW_FILTER_VALUE}}"
+            value: ""
           - name: EXCLUDE_INTERFACES
             value: "lo"
           - name: SAMPLING
             value: "1"
           - name: ENABLE_RTT
-            value: "true"
+            value: ""
           - name: ENABLE_PKT_DROPS
-            value: "true"
+            value: ""
           - name: ENABLE_DNS_TRACKING
-            value: "true"
+            value: ""
+          - name: ENABLE_FLOW_FILTER
+            value: ""
+          - name: FLOW_FILTER_DIRECTION
+            value: ""
+          - name: FLOW_FILTER_IP_CIDR
+            value: ""
+          - name: FLOW_FILTER_PROTOCOL
+            value: ""
+          - name: FLOW_FILTER_SOURCE_PORT
+            value: ""
+          - name: FLOW_FILTER_DESTINATION_PORT
+            value: ""
+          - name: FLOW_FILTER_PORT
+            value: ""
+          - name:  FLOW_FILTER_SOURCE_PORT_RANGE
+            value: ""
+          - name: FLOW_FILTER_DESTINATION_PORT_RANGE
+            value: ""
+          - name: FLOW_FILTER_PORT_RANGE
+            value: ""
+          - name: FLOW_FILTER_ICMP_TYPE
+            value: ""
+          - name: FLOW_FILTER_ICMP_CODE
+            value: ""
+          - name: FLOW_FILTER_PEER_IP
+            value: ""
+          - name: FLOW_FILTER_ACTION
+            value: ""
           - name: EXPORT
             value: "direct-flp"
           - name: FLP_CONFIG


### PR DESCRIPTION
## Description

how we can pass in flow filter configs and use it to update flow collector manifests

Example
```sh
netobserv flows --interfaces=eth0 --enable=true --protocol="TCP" --cidr=0.0.0.0/0 --port-range="80-100" --peer-ip="1.1.1.1" --action=Accept
```
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
