### PR TITLE
move the help menu for filters to the main help menu

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -24,6 +24,7 @@ case "$1" in
     echo
     echo "options:"
     echo "  flows      Capture flows information. You can specify an optionnal interface name as filter such as 'netobserv flows br-ex'."
+    usage
     echo "  packets    Capture packets from a specific protocol/port pair such as 'netobserv packets tcp,80'."
     echo "  cleanup    Remove netobserv components."
     echo "  version    Print software version."

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -102,10 +102,6 @@ function setup {
         key="${option%%=*}"
         value="${option#*=}"
         case "$key" in
-            --help) # show help
-                usage
-                exit
-                ;;
             --interfaces) # Interfaces
                 edit_manifest "interfaces" "$value" "$manifest"
                 ;;
@@ -221,27 +217,25 @@ function cleanup {
 }
 
 function usage {
-  echo "Usage: [OPTIONS]"
-  echo "Options:"
-  echo "  --help: show this help message"
-  echo "  --interfaces: interfaces to monitor"
-  echo "  --enable_pktdrop: enable packet drop (default: true)"
-  echo "  --enable_dns: enable DNS tracking (default: true)"
-  echo "  --enable_rtt: enable RTT tracking (default: true)"
-  echo "  --enable_filter: enable flow filter (default: false)"
-  echo "  --direction: flow filter direction"
-  echo "  --cidr: flow filter CIDR (default: 0.0.0.0/0)"
-  echo "  --protocol: flow filter protocol (default: TCP)"
-  echo "  --sport: flow filter source port"
-  echo "  --dport: flow filter destination port"
-  echo "  --port: flow filter port"
-  echo "  --sport_range: flow filter source port range"
-  echo "  --dport_range: flow filter destination port range"
-  echo "  --port_range: flow filter port range"
-  echo "  --icmp_type: ICMP type"
-  echo "  --icmp_code: ICMP code"
-  echo "  --peer_ip: peer IP"
-  echo "  --action: flow filter action (default: Accept)"
+  echo "        Options:"
+  echo "          --interfaces: interfaces to monitor"
+  echo "          --enable_pktdrop: enable packet drop (default: true)"
+  echo "          --enable_dns: enable DNS tracking (default: true)"
+  echo "          --enable_rtt: enable RTT tracking (default: true)"
+  echo "          --enable_filter: enable flow filter (default: false)"
+  echo "          --direction: flow filter direction"
+  echo "          --cidr: flow filter CIDR (default: 0.0.0.0/0)"
+  echo "          --protocol: flow filter protocol (default: TCP)"
+  echo "          --sport: flow filter source port"
+  echo "          --dport: flow filter destination port"
+  echo "          --port: flow filter port"
+  echo "          --sport_range: flow filter source port range"
+  echo "          --dport_range: flow filter destination port range"
+  echo "          --port_range: flow filter port range"
+  echo "          --icmp_type: ICMP type"
+  echo "          --icmp_code: ICMP code"
+  echo "          --peer_ip: peer IP"
+  echo "          --action: flow filter action (default: Accept)"
 }
 
 function edit_manifest() {


### PR DESCRIPTION
## Description

move filters help to the main help menu

```shell
 ./commands/netobserv help

Netobserv allows you to capture flow and packets from your cluster.
Find more information at: https://github.com/netobserv/network-observability-cli/

Syntax: netobserv [flows|packets|cleanup] [filters]

options:
  flows      Capture flows information. You can specify an optionnal interface name as filter such as 'netobserv flows br-ex'.
    Options:
    --interfaces: interfaces to monitor
    --enable_pktdrop: enable packet drop (default: true)
    --enable_dns: enable DNS tracking (default: true)
    --enable_rtt: enable RTT tracking (default: true)
    --enable_filter: enable flow filter (default: false)
    --direction: flow filter direction
    --cidr: flow filter CIDR (default: 0.0.0.0/0)
    --protocol: flow filter protocol (default: TCP)
    --sport: flow filter source port
    --dport: flow filter destination port
    --port: flow filter port
    --sport_range: flow filter source port range
    --dport_range: flow filter destination port range
    --port_range: flow filter port range
    --icmp_type: ICMP type
    --icmp_code: ICMP code
    --peer_ip: peer IP
    --action: flow filter action (default: Accept)
  packets    Capture packets from a specific protocol/port pair such as 'netobserv packets tcp,80'.
  cleanup    Remove netobserv components.
  version    Print software version.

```
## Dependencies


n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
