### PR TITLE
NETOBSERV-1623 update sed commands to support macos

### DIFF
--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -6,21 +6,21 @@ if [ -z "$IMAGE" ]; then
   echo "image not provided, keeping current one"
 else 
   echo "updating CLI images to $IMAGE"
-  sed -i'' -e "/img=/c\img=\"$IMAGE\"" ./tmp/netobserv
+  sed -i.bak -e "/img=/c\img=\"$IMAGE\"" ./tmp/netobserv
 fi
 
 if [ -z "$PULL_POLICY" ]; then
   echo "pull policy not provided, keeping current one"
 else 
   echo "updating CLI pull policy to $PULL_POLICY"
-  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$PULL_POLICY' \\\\" ./tmp/netobserv
+  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$PULL_POLICY' \\\\" ./tmp/netobserv
 fi
 
 if [ -z "$VERSION" ]; then
   echo "version not provided, keeping current one"
 else 
   echo "updating CLI version to $VERSION"
-  sed -i'' -e "/version=/c\version=\"$VERSION\"" ./tmp/netobserv
+  sed -i.bak -e "/version=/c\version=\"$VERSION\"" ./tmp/netobserv
 fi
 
 prefix=
@@ -31,9 +31,9 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
   fi 
   echo "updating K8S CLI to $K8S_CLI_BIN"
   # remove unecessary call
-  sed -i'' -e "/K8S_CLI_BIN_PATH=/d" ./tmp/functions.sh
+  sed -i.bak -e "/K8S_CLI_BIN_PATH=/d" ./tmp/functions.sh
   # replace only first match to force default
-  sed -i'' -e "0,/K8S_CLI_BIN=/c\K8S_CLI_BIN=$K8S_CLI_BIN" ./tmp/functions.sh
+  sed -i.bak -e "0,/K8S_CLI_BIN=/c\K8S_CLI_BIN=$K8S_CLI_BIN" ./tmp/functions.sh
   # prefix with oc / kubectl for local install
   prefix="$K8S_CLI_BIN-"
   echo "prefixing with $prefix"
@@ -41,24 +41,25 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
 fi
 
 # inject YAML files to functions.sh
-sed -i'' -e '/namespaceYAMLContent/{r ./res/namespace.yml' -e 'd}' ./tmp/functions.sh
-sed -i'' -e '/saYAMLContent/{r ./res/service-account.yml' -e 'd}' ./tmp/functions.sh
-sed -i'' -e '/flowAgentYAMLContent/{r ./res/flow-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i'' -e '/packetAgentYAMLContent/{r ./res/packet-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i'' -e '/collectorServiceYAMLContent/{r ./res/collector-service.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak -e '/namespaceYAMLContent/{r ./res/namespace.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak -e '/saYAMLContent/{r ./res/service-account.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak -e '/flowAgentYAMLContent/{r ./res/flow-capture.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak -e '/packetAgentYAMLContent/{r ./res/packet-capture.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak -e '/collectorServiceYAMLContent/{r ./res/collector-service.yml' -e 'd}' ./tmp/functions.sh
 
 # inject updated functions to commands
-sed -i'' -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/"$prefix"netobserv
+sed -i.bak -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/"$prefix"netobserv
 
 if [ -z "$3" ]; then
   echo "pull policy not provided, keeping current ones"
 else 
   echo "updating CLI pull policy to $3"
-  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-flows
-  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-packets
+  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-flows
+  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-packets
 fi
 
 rm ./tmp/functions.sh
+rm ./tmp/*.bak
 
 if [ -z "$DIST_DIR" ]; then
   echo "output generated in tmp folder"

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -4,23 +4,23 @@ cp ./scripts/functions.sh ./tmp/functions.sh
 
 if [ -z "$IMAGE" ]; then
   echo "image not provided, keeping current one"
-else 
+else
   echo "updating CLI images to $IMAGE"
-  sed -i.bak -e "/img=/c\img=\"$IMAGE\"" ./tmp/netobserv
+  sed -i.bak "s|^img=.*|img=\"$IMAGE\"|" ./tmp/netobserv
 fi
 
 if [ -z "$PULL_POLICY" ]; then
   echo "pull policy not provided, keeping current one"
-else 
+else
   echo "updating CLI pull policy to $PULL_POLICY"
-  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$PULL_POLICY' \\\\" ./tmp/netobserv
+  sed -i.bak "s/--image-pull-policy=.*/--image-pull-policy='$PULL_POLICY' \\\\/" ./tmp/netobserv
 fi
 
 if [ -z "$VERSION" ]; then
   echo "version not provided, keeping current one"
-else 
+else
   echo "updating CLI version to $VERSION"
-  sed -i.bak -e "/version=/c\version=\"$VERSION\"" ./tmp/netobserv
+  sed -i.bak "s/^version=.*/version=\"$VERSION\"/" ./tmp/netobserv
 fi
 
 prefix=
@@ -28,12 +28,12 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
   if [ -z "$K8S_CLI_BIN" ]; then
     echo "ERROR: K8S CLI not provided"
     exit 1
-  fi 
+  fi
   echo "updating K8S CLI to $K8S_CLI_BIN"
-  # remove unecessary call
-  sed -i.bak -e "/K8S_CLI_BIN_PATH=/d" ./tmp/functions.sh
+  # remove beginning lines
+  sed -i.bak '1,/K8S_CLI_BIN_PATH=/d' ./tmp/functions.sh
   # replace only first match to force default
-  sed -i.bak -e "0,/K8S_CLI_BIN=/c\K8S_CLI_BIN=$K8S_CLI_BIN" ./tmp/functions.sh
+  sed -i.bak "s/^K8S_CLI_BIN=.*/K8S_CLI_BIN=$K8S_CLI_BIN/" ./tmp/functions.sh
   # prefix with oc / kubectl for local install
   prefix="$K8S_CLI_BIN-"
   echo "prefixing with $prefix"
@@ -41,21 +41,33 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
 fi
 
 # inject YAML files to functions.sh
-sed -i.bak -e '/namespaceYAMLContent/{r ./res/namespace.yml' -e 'd}' ./tmp/functions.sh
-sed -i.bak -e '/saYAMLContent/{r ./res/service-account.yml' -e 'd}' ./tmp/functions.sh
-sed -i.bak -e '/flowAgentYAMLContent/{r ./res/flow-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i.bak -e '/packetAgentYAMLContent/{r ./res/packet-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i.bak -e '/collectorServiceYAMLContent/{r ./res/collector-service.yml' -e 'd}' ./tmp/functions.sh
+sed -i.bak '/namespaceYAMLContent/{r ./res/namespace.yml
+d
+}' ./tmp/functions.sh
+sed -i.bak '/saYAMLContent/{r ./res/service-account.yml
+d
+}' ./tmp/functions.sh
+sed -i.bak '/flowAgentYAMLContent/{r ./res/flow-capture.yml
+d
+}' ./tmp/functions.sh
+sed -i.bak '/packetAgentYAMLContent/{r ./res/packet-capture.yml
+d
+}' ./tmp/functions.sh
+sed -i.bak '/collectorServiceYAMLContent/{r ./res/collector-service.yml
+d
+}' ./tmp/functions.sh
 
 # inject updated functions to commands
-sed -i.bak -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/"$prefix"netobserv
+sed -i.bak '/source.*/{r ./tmp/functions.sh
+d
+}' ./tmp/"$prefix"netobserv
 
 if [ -z "$3" ]; then
   echo "pull policy not provided, keeping current ones"
-else 
+else
   echo "updating CLI pull policy to $3"
-  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-flows
-  sed -i.bak -e "/  --i.bakmage-pull-policy/c\  --i.bakmage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-packets
+  sed -i.bak "s/--image-pull-policy=.*/--image-pull-policy='$3' \\\\/" ./tmp/oc-netobserv-flows
+  sed -i.bak "s/--image-pull-policy=.*/--image-pull-policy='$3' \\\\/" ./tmp/oc-netobserv-packets
 fi
 
 rm ./tmp/functions.sh
@@ -63,7 +75,7 @@ rm ./tmp/*.bak
 
 if [ -z "$DIST_DIR" ]; then
   echo "output generated in tmp folder"
-else 
+else
   echo "output generated in $DIST_DIR folder"
   cp -a ./tmp/. ./"$DIST_DIR"
   rm -rf ./tmp

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -6,21 +6,21 @@ if [ -z "$IMAGE" ]; then
   echo "image not provided, keeping current one"
 else 
   echo "updating CLI images to $IMAGE"
-  sed -i "/img=/c\img=\"$IMAGE\"" ./tmp/netobserv
+  sed -i'' -e "/img=/c\img=\"$IMAGE\"" ./tmp/netobserv
 fi
 
 if [ -z "$PULL_POLICY" ]; then
   echo "pull policy not provided, keeping current one"
 else 
   echo "updating CLI pull policy to $PULL_POLICY"
-  sed -i "/  --image-pull-policy/c\  --image-pull-policy='$PULL_POLICY' \\\\" ./tmp/netobserv
+  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$PULL_POLICY' \\\\" ./tmp/netobserv
 fi
 
 if [ -z "$VERSION" ]; then
   echo "version not provided, keeping current one"
 else 
   echo "updating CLI version to $VERSION"
-  sed -i "/version=/c\version=\"$VERSION\"" ./tmp/netobserv
+  sed -i'' -e "/version=/c\version=\"$VERSION\"" ./tmp/netobserv
 fi
 
 prefix=
@@ -31,9 +31,9 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
   fi 
   echo "updating K8S CLI to $K8S_CLI_BIN"
   # remove unecessary call
-  sed -i "/K8S_CLI_BIN_PATH=/d" ./tmp/functions.sh
+  sed -i'' -e "/K8S_CLI_BIN_PATH=/d" ./tmp/functions.sh
   # replace only first match to force default
-  sed -i "0,/K8S_CLI_BIN=/c\K8S_CLI_BIN=$K8S_CLI_BIN" ./tmp/functions.sh
+  sed -i'' -e "0,/K8S_CLI_BIN=/c\K8S_CLI_BIN=$K8S_CLI_BIN" ./tmp/functions.sh
   # prefix with oc / kubectl for local install
   prefix="$K8S_CLI_BIN-"
   echo "prefixing with $prefix"
@@ -41,21 +41,21 @@ if [ -z "$KREW_PLUGIN" ] || [ "$KREW_PLUGIN" = "false" ]; then
 fi
 
 # inject YAML files to functions.sh
-sed -i -e '/namespaceYAMLContent/{r ./res/namespace.yml' -e 'd}' ./tmp/functions.sh
-sed -i -e '/saYAMLContent/{r ./res/service-account.yml' -e 'd}' ./tmp/functions.sh
-sed -i -e '/flowAgentYAMLContent/{r ./res/flow-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i -e '/packetAgentYAMLContent/{r ./res/packet-capture.yml' -e 'd}' ./tmp/functions.sh
-sed -i -e '/collectorServiceYAMLContent/{r ./res/collector-service.yml' -e 'd}' ./tmp/functions.sh
+sed -i'' -e '/namespaceYAMLContent/{r ./res/namespace.yml' -e 'd}' ./tmp/functions.sh
+sed -i'' -e '/saYAMLContent/{r ./res/service-account.yml' -e 'd}' ./tmp/functions.sh
+sed -i'' -e '/flowAgentYAMLContent/{r ./res/flow-capture.yml' -e 'd}' ./tmp/functions.sh
+sed -i'' -e '/packetAgentYAMLContent/{r ./res/packet-capture.yml' -e 'd}' ./tmp/functions.sh
+sed -i'' -e '/collectorServiceYAMLContent/{r ./res/collector-service.yml' -e 'd}' ./tmp/functions.sh
 
 # inject updated functions to commands
-sed -i -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/"$prefix"netobserv
+sed -i'' -e '/source.*/{r ./tmp/functions.sh' -e 'd}' ./tmp/"$prefix"netobserv
 
 if [ -z "$3" ]; then
   echo "pull policy not provided, keeping current ones"
 else 
   echo "updating CLI pull policy to $3"
-  sed -i "/  --image-pull-policy/c\  --image-pull-policy='$3' \\\\" ./tmp/oc-netobserv-flows
-  sed -i "/  --image-pull-policy/c\  --image-pull-policy='$3' \\\\" ./tmp/oc-netobserv-packets
+  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-flows
+  sed -i'' -e "/  --i''mage-pull-policy/c\  --i''mage-pull-policy='$3' \\\\" ./tmp/oc-netobserv-packets
 fi
 
 rm ./tmp/functions.sh


### PR DESCRIPTION
## Description

Attempt to make `sed` working on MacOs.

Run the following target to give a try:
```bash
$ make oc-commands 
### Generating oc commands
DIST_DIR=build \
K8S_CLI_BIN=oc \
IMAGE=quay.io/julien/network-observability-cli:main \
PULL_POLICY=Always \
VERSION=main \
./scripts/inject.sh
updating CLI images to quay.io/julien/network-observability-cli:main
updating CLI pull policy to Always
updating CLI version to main
updating K8S CLI to oc
prefixing with oc-
pull policy not provided, keeping current ones
output generated in build folder
```

The generated file `./build/oc-netobserv` should contains YAMLs and your quay image with version main.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
