### PR TITLE
[backport] allow custom image at run time (#42)

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -1,11 +1,18 @@
 #!/bin/bash
 source "./scripts/functions.sh"
 
+set +u
+
 # interface filter such as 'br-ex' or pcap filter such as 'tcp,80'
 filter=""
 
 # CLI image to use
 img="quay.io/netobserv/network-observability-cli:main"
+
+if [ ! -z "$NETOBSERV_COLLECTOR_IMAGE" ]; then
+  echo "using custom collector image $NETOBSERV_COLLECTOR_IMAGE"
+  img="$NETOBSERV_COLLECTOR_IMAGE"
+fi
 
 # version to display
 version="0.0.1"


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
