### PR TITLE
NETOBSERV-1678: allow agent image configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ IMAGE_TAG_BASE ?= quay.io/$(IMAGE_ORG)/$(NAME)
 # Image URL to use all building/pushing image targets
 IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
 PULL_POLICY ?=Always
+# Agent image URL to deploy
+AGENT_IMAGE ?= quay.io/netobserv/netobserv-ebpf-agent:main
 OCI_BUILD_OPTS ?=
 
 # Image building tool (docker / podman) - docker is preferred in CI
@@ -159,6 +161,7 @@ commands: ## Generate either oc or kubectl plugins and add them to build folder
 	K8S_CLI_BIN=$(K8S_CLI_BIN) \
 	IMAGE=$(IMAGE) \
 	PULL_POLICY=$(PULL_POLICY) \
+	AGENT_IMAGE=$(AGENT_IMAGE) \
 	VERSION=$(VERSION) \
 	./scripts/inject.sh
 

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -9,7 +9,7 @@ filter=""
 # CLI image to use
 img="quay.io/netobserv/network-observability-cli:main"
 
-if [ ! -z "$NETOBSERV_COLLECTOR_IMAGE" ]; then
+if [ -n "$NETOBSERV_COLLECTOR_IMAGE" ]; then
   echo "using custom collector image $NETOBSERV_COLLECTOR_IMAGE"
   img="$NETOBSERV_COLLECTOR_IMAGE"
 fi

--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: netobserv-cli
-        image: quay.io/netobserv/netobserv-ebpf-agent:main
+        image: "{{AGENT_IMAGE_URL}}"
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -19,7 +19,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: netobserv-cli
-        image: quay.io/netobserv/netobserv-ebpf-agent:main
+        image: "{{AGENT_IMAGE_URL}}"
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -8,6 +8,14 @@ set -eu
 K8S_CLI_BIN_PATH=$( which oc 2>/dev/null || which kubectl 2>/dev/null )
 K8S_CLI_BIN=$( basename "${K8S_CLI_BIN_PATH}" )
 
+# eBPF agent image to use
+agentImg="quay.io/netobserv/netobserv-ebpf-agent:main"
+
+if [ -n "$NETOBSERV_AGENT_IMAGE" ]; then
+  echo "using custom agent image $NETOBSERV_AGENT_IMAGE"
+  agentImg="$NETOBSERV_AGENT_IMAGE"
+fi
+
 function loadYAMLs() {
   namespaceYAML='
     namespaceYAMLContent
@@ -29,6 +37,7 @@ function loadYAMLs() {
   if [ -f ./res/flow-capture.yml ]; then
     flowAgentYAML="$(cat ./res/flow-capture.yml)"
   fi
+  flowAgentYAML="${flowAgentYAML/"{{AGENT_IMAGE_URL}}"/${agentImg}}"
 
   packetAgentYAML='
     packetAgentYAMLContent
@@ -36,6 +45,7 @@ function loadYAMLs() {
   if [ -f ./res/packet-capture.yml ]; then
     packetAgentYAML="$(cat ./res/packet-capture.yml)"
   fi
+  packetAgentYAML="${packetAgentYAML/"{{AGENT_IMAGE_URL}}"/${agentImg}}"
 
   collectorServiceYAML='
     collectorServiceYAMLContent

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -16,6 +16,13 @@ else
   sed -i.bak "s/--image-pull-policy=.*/--image-pull-policy='$PULL_POLICY' \\\\/" ./tmp/netobserv
 fi
 
+if [ -z "$AGENT_IMAGE" ]; then
+  echo "eBPF agent image not provided, keeping current one"
+else
+  echo "updating eBPF agent images to $AGENT_IMAGE"
+  sed -i.bak "s|^agentImg=.*|agentImg=\"$AGENT_IMAGE\"|" ./tmp/functions.sh
+fi
+
 if [ -z "$VERSION" ]; then
   echo "version not provided, keeping current one"
 else


### PR DESCRIPTION
## Description

- Configure agent image at build time using `AGENT_IMAGE` param

```
$ USER=netobserv VERSION=main AGENT_IMAGE=quay.io/netobserv/netobserv-ebpf-agent:release-1.6 make oc-commands 
### Generating oc commands
DIST_DIR=build \
K8S_CLI_BIN=oc \
IMAGE=quay.io/netobserv/network-observability-cli:main \
PULL_POLICY=Always \
AGENT_IMAGE=quay.io/netobserv/netobserv-ebpf-agent:release-1.6 \
VERSION=main \
./scripts/inject.sh
updating CLI images to quay.io/netobserv/network-observability-cli:main
updating CLI version to main
updating CLI pull policy to Always
updating eBPF agent images to quay.io/netobserv/netobserv-ebpf-agent:release-1.6
updating K8S CLI to oc
prefixing with oc-
pull policy not provided, keeping current ones
output generated in build folder
```

- Override agent image at run time using `NETOBSERV_AGENT_IMAGE` environment variable
```
$ NETOBSERV_AGENT_IMAGE=quay.io/netobserv/netobserv-ebpf-agent:release-1.6 ./build/oc-netobserv flows
```

Both will result in custom eBPF agent image set as:
```
$ oc describe pod netobserv-cli-chz4p -n netobserv-cli
Name:             netobserv-cli-chz4p
Namespace:        netobserv-cli
Containers:
  netobserv-cli:
    Image:          quay.io/netobserv/netobserv-ebpf-agent:release-1.6
...
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
