### PR TITLE
NETOBSERV-1617: use filter with packets capture feature

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -30,9 +30,10 @@ case "$1" in
     echo "Syntax: netobserv [flows|packets|cleanup] [filters]"
     echo
     echo "options:"
-    echo "  flows      Capture flows information. You can specify an optionnal interface name as filter such as 'netobserv flows br-ex'."
-    usage
-    echo "  packets    Capture packets from a specific protocol/port pair such as 'netobserv packets tcp,80'."
+    echo "  flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'."
+    flows_usage
+    echo "  packets    Capture packets information in pcap format."
+    packets_usage
     echo "  cleanup    Remove netobserv components."
     echo "  version    Print software version."
     echo
@@ -47,13 +48,8 @@ case "$1" in
     # run flows command
     command="flows" ;;
 "packets")
-    if [ -z "${2:-}" ]; then
-      echo "Specify a valid filter as first argument such as 'tcp,80'."
-      exit 1
-    else
-      echo "Filters set as $2"
-      filter=$2
-    fi
+    shift # remove first argument
+    filter="$*"
     # run packets command
     command="packets" ;;
 "cleanup")

--- a/docs/netobserv_cli_packets_config.md
+++ b/docs/netobserv_cli_packets_config.md
@@ -1,0 +1,36 @@
+# Netobserv CLI
+
+Users of Netobserv CLI can pass command line arguments to enable feature or pass configuration options to the eBPF agent.
+This document lists all the supported command line options and their possible values.
+
+## Command line arguments
+
+- To build the Netobserv CLI commands locally
+
+```shell
+USER=netobserv make commands
+```
+
+- Example of running Netobserv CLI with some options
+
+```shell
+./build/oc-netobserv packets --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
+```
+
+- The following table shows filter configuration options.
+
+| Option          | Description                                 | Possible values                                  | Mandatory | Default   |
+|-----------------|---------------------------------------------|--------------------------------------------------|-----------|-----------|
+| --action        | Action to apply on the flow                 | Accept, Reject                                   | yes       | Accept    |
+| --cidr          | CIDR to match on the flow                   | for example 1.1.1.0/24 or 1::100/64 or 0.0.0.0/0 | yes       | 0.0.0.0/0 |
+| --protocol      | Protocol to match on the flow               | TCP, UDP, SCTP, ICMP, ICMPv6                     | no        |           |
+| --direction     | Direction to match on the flow              | Ingress, Egress                                  | no        |           |
+| --dport         | Destination port to match on the flow       | for example 80 or 443 or 49051                   | no        |           |
+| --sport         | Source port to match on the flow            | for example 80 or 443 or 49051                   | no        |           |
+| --port          | Port to match on the flow                   | for example 80 or 443 or 49051                   | no        |           |
+| --sport_range   | Source port range to match on the flow      | for example 80-100 or 443-445                    | no        |           |
+| --dport_range   | Destination port range to match on the flow | for example 80-100                               | no        |           |
+| --port_range    | Port range to match on the flow             | for example 80-100 or 443-445                    | no        |           |
+| --icmp_type     | ICMP type to match on the flow              | for example 8 or 13                              | no        |           |
+| --icmp_code     | ICMP code to match on the flow              | for example 0 or 1                               | no        |           |
+| --peer_ip       | Peer IP to match on the flow                | for example 1.1.1.1 or 1::1                      | no        |           |

--- a/e2e/capture_test.go
+++ b/e2e/capture_test.go
@@ -113,7 +113,7 @@ func TestFlowCapture(t *testing.T) {
 func TestPacketCapture(t *testing.T) {
 	f1 := features.New("packet capture").Setup(
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			output, err := RunCommand(clog, "oc-netobserv", "packets", "tcp,443")
+			output, err := RunCommand(clog, "oc-netobserv", "packets", "--protocol=TCP", "--port=443")
 			// TODO: find a way to avoid error here; this is probably related to SIGTERM instead of CTRL + C call
 			//assert.Nil(t, err)
 

--- a/e2e/script_test.go
+++ b/e2e/script_test.go
@@ -30,8 +30,8 @@ func TestHelpCommand(t *testing.T) {
 		assert.Contains(t, str, "Find more information at: https://github.com/netobserv/network-observability-cli/")
 		// ensure help to display proper options
 		assert.Contains(t, str, "Syntax: netobserv [flows|packets|cleanup] [filters]")
-		assert.Contains(t, str, "flows      Capture flows information. You can specify an optionnal interface name as filter such as 'netobserv flows br-ex'.")
-		assert.Contains(t, str, "packets    Capture packets from a specific protocol/port pair such as 'netobserv packets tcp,80'.")
+		assert.Contains(t, str, "flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'.")
+		assert.Contains(t, str, "packets    Capture packets information in pcap format.")
 		assert.Contains(t, str, "cleanup    Remove netobserv components.")
 		assert.Contains(t, str, "version    Print software version.")
 	})

--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -43,31 +43,31 @@ spec:
             value: "false"
           - name: ENABLE_FLOW_FILTER
             value: "false"
-          - name: FLOW_FILTER_DIRECTION
+          - name: FILTER_DIRECTION
             value: ""
-          - name: FLOW_FILTER_IP_CIDR
+          - name: FILTER_IP_CIDR
             value: "0.0.0.0/0"
-          - name: FLOW_FILTER_PROTOCOL
+          - name: FILTER_PROTOCOL
             value: ""
-          - name: FLOW_FILTER_SOURCE_PORT
+          - name: FILTER_SOURCE_PORT
             value: ""
-          - name: FLOW_FILTER_DESTINATION_PORT
+          - name: FILTER_DESTINATION_PORT
             value: ""
-          - name: FLOW_FILTER_PORT
+          - name: FILTER_PORT
             value: ""
-          - name:  FLOW_FILTER_SOURCE_PORT_RANGE
+          - name:  FILTER_SOURCE_PORT_RANGE
             value: ""
-          - name: FLOW_FILTER_DESTINATION_PORT_RANGE
+          - name: FILTER_DESTINATION_PORT_RANGE
             value: ""
-          - name: FLOW_FILTER_PORT_RANGE
+          - name: FILTER_PORT_RANGE
             value: ""
-          - name: FLOW_FILTER_ICMP_TYPE
+          - name: FILTER_ICMP_TYPE
             value: ""
-          - name: FLOW_FILTER_ICMP_CODE
+          - name: FILTER_ICMP_CODE
             value: ""
-          - name: FLOW_FILTER_PEER_IP
+          - name: FILTER_PEER_IP
             value: ""
-          - name: FLOW_FILTER_ACTION
+          - name: FILTER_ACTION
             value: "Accept"
           - name: EXPORT
             value: "direct-flp"

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -31,8 +31,32 @@ spec:
             value: trace
           - name: ENABLE_PCA
             value: "true"
-          - name: PCA_FILTER
-            value: "{{PCA_FILTER_VALUE}}"
+          - name: FILTER_DIRECTION
+            value: ""
+          - name: FILTER_IP_CIDR
+            value: "0.0.0.0/0"
+          - name: FILTER_PROTOCOL
+            value: ""
+          - name: FILTER_SOURCE_PORT
+            value: ""
+          - name: FILTER_DESTINATION_PORT
+            value: ""
+          - name: FILTER_PORT
+            value: ""
+          - name:  FILTER_SOURCE_PORT_RANGE
+            value: ""
+          - name: FILTER_DESTINATION_PORT_RANGE
+            value: ""
+          - name: FILTER_PORT_RANGE
+            value: ""
+          - name: FILTER_ICMP_TYPE
+            value: ""
+          - name: FILTER_ICMP_CODE
+            value: ""
+          - name: FILTER_PEER_IP
+            value: ""
+          - name: FILTER_ACTION
+            value: "Accept"
           - name: TARGET_HOST
             value: "collector.netobserv-cli.svc.cluster.local"
           - name: TARGET_PORT


### PR DESCRIPTION
## Description

add filter capability for pca feature
Example from running on `Kind` cluster
- build commands locally and use agent custom image

```sh
NETOBSERV_AGENT_IMAGE=quay.io/netobserv/netobserv-ebpf-agent:f525832 ./build/oc-netobserv packets --protocol="TCP" --port=443
```

output pcap
```sh
tcpdump -r 2024-06-27T110645Z.pcap 
reading from file 2024-06-27T110645Z.pcap, link-type EN10MB (Ethernet), snapshot length 262144
07:06:57.502363 IP 172.18.0.3.41396 > ec2-52-204-93-25.compute-1.amazonaws.com.https: Flags [P.], seq 2078794407:2078794438, ack 1312010586, win 458, options [nop,nop,TS val 3614985982 ecr 3018431589], length 31
07:06:57.502422 IP 172.18.0.3.41396 > ec2-52-204-93-25.compute-1.amazonaws.com.https: Flags [F.], seq 31, ack 1, win 458, options [nop,nop,TS val 3614985982 ecr 3018431589], length 0
07:06:57.531353 IP ec2-52-204-93-25.compute-1.amazonaws.com.https > 172.18.0.3.41396: Flags [.], ack 31, win 114, options [nop,nop,TS val 3018461620 ecr 3614985982], length 0
07:06:57.531372 IP ec2-52-204-93-25.compute-1.amazonaws.com.https > 172.18.0.3.41396: Flags [F.], seq 1, ack 32, win 114, options [nop,nop,TS val 3018461620 ecr 3614985982], length 0
07:06:57.531381 IP 172.18.0.3.41396 > ec2-52-204-93-25.compute-1.amazonaws.com.https: Flags [.], ack 2, win 458, options [nop,nop,TS val 3614986011 ecr 3018461620], length 0
07:06:58.819363 IP 172.18.0.3.37132 > ec2-44-216-66-253.compute-1.amazonaws.com.https: Flags [P.], seq 1277682538:1277682569, ack 1218593254, win 461, options [nop,nop,TS val 1795579274 ecr 783897356], length 31

```
## Dependencies

https://github.com/netobserv/netobserv-ebpf-agent/pull/359

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
