### PR TITLE
NETOBSERV-1684 Auto teardown after some time / number of flows / packets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,13 +23,17 @@ var (
 	ports    []int
 	nodes    []string
 	filter   string
+	maxTime  time.Duration
+	maxBytes int64
 
 	currentTime = func() time.Time {
 		return time.Now()
 	}
 	startupTime = currentTime()
 	lastRefresh = startupTime
-	mutex       = sync.Mutex{}
+	totalBytes  = int64(0)
+
+	mutex = sync.Mutex{}
 
 	resetTerminal = func() {
 		// clear terminal to render table properly
@@ -63,6 +67,8 @@ func init() {
 	rootCmd.PersistentFlags().IntSliceVarP(&ports, "ports", "", []int{9999}, "TCP ports to listen")
 	rootCmd.PersistentFlags().StringSliceVarP(&nodes, "nodes", "", []string{""}, "Node names per port (optionnal)")
 	rootCmd.PersistentFlags().StringVarP(&filter, "filter", "", "", "Filter(s)")
+	rootCmd.PersistentFlags().DurationVarP(&maxTime, "maxtime", "", 5*time.Minute, "Maximum capture time")
+	rootCmd.PersistentFlags().Int64VarP(&maxBytes, "maxbytes", "", 50000000, "Maximum capture bytes")
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGTERM)

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -20,6 +20,15 @@ version="0.0.1"
 # command to run
 command=""
 
+# log level (default: info)
+logLevel="info"
+
+# max time (default: 5min)
+maxTime="5m" 
+
+# max bytes (default: 50MB)
+maxBytes=50000000
+
 case "$1" in  
 "help")
     # display Help
@@ -27,7 +36,7 @@ case "$1" in
     echo "Netobserv allows you to capture flow and packets from your cluster."
     echo "Find more information at: https://github.com/netobserv/network-observability-cli/"
     echo
-    echo "Syntax: netobserv [flows|packets|cleanup] [filters]"
+    echo "Syntax: netobserv [flows|packets|cleanup] [options]"
     echo
     echo "options:"
     echo "  flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'."
@@ -81,4 +90,4 @@ ${K8S_CLI_BIN} wait \
 ${K8S_CLI_BIN} exec -i --tty \
   -n netobserv-cli \
   collector \
-  -- /network-observability-cli get-$command ${filter:+"--filter" "$filter"}
+  -- /network-observability-cli get-$command ${filter:+"--filter" "${filter//--/}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes

--- a/docs/netobserv_cli_flows_config.md
+++ b/docs/netobserv_cli_flows_config.md
@@ -44,3 +44,6 @@ USER=netobserv make commands
 | --icmp_type     | ICMP type to match on the flow              | for example 8 or 13                              | no        |           |
 | --icmp_code     | ICMP code to match on the flow              | for example 0 or 1                               | no        |           |
 | --peer_ip       | Peer IP to match on the flow                | for example 1.1.1.1 or 1::1                      | no        |           |
+| --log-level     | Components logs                             | for example debug or trace                       | no        | info      |
+| --max-time      | Maximum capture time                        | for example 10m or 30s                           | no        | 5m        |
+| --max-bytes     | max-bytes: maximum capture bytes            | for example 10000000 (1MB)                       | no        | 50000000  |

--- a/docs/netobserv_cli_packets_config.md
+++ b/docs/netobserv_cli_packets_config.md
@@ -34,3 +34,6 @@ USER=netobserv make commands
 | --icmp_type     | ICMP type to match on the flow              | for example 8 or 13                              | no        |           |
 | --icmp_code     | ICMP code to match on the flow              | for example 0 or 1                               | no        |           |
 | --peer_ip       | Peer IP to match on the flow                | for example 1.1.1.1 or 1::1                      | no        |           |
+| --log-level     | Components logs                             | for example debug or trace                       | no        | info      |
+| --max-time      | Maximum capture time                        | for example 10m or 30s                           | no        | 5m        |
+| --max-bytes     | max-bytes: maximum capture bytes            | for example 10000000 (1MB)                       | no        | 50000000  |

--- a/e2e/script_test.go
+++ b/e2e/script_test.go
@@ -29,7 +29,7 @@ func TestHelpCommand(t *testing.T) {
 		assert.Contains(t, str, "Netobserv allows you to capture flow and packets from your cluster.")
 		assert.Contains(t, str, "Find more information at: https://github.com/netobserv/network-observability-cli/")
 		// ensure help to display proper options
-		assert.Contains(t, str, "Syntax: netobserv [flows|packets|cleanup] [filters]")
+		assert.Contains(t, str, "Syntax: netobserv [flows|packets|cleanup] [options]")
 		assert.Contains(t, str, "flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'.")
 		assert.Contains(t, str, "packets    Capture packets information in pcap format.")
 		assert.Contains(t, str, "cleanup    Remove netobserv components.")

--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -28,7 +28,7 @@ spec:
           - name: METRICS_ENABLE
             value: "false"
           - name: LOG_LEVEL
-            value: trace
+            value: info
           - name: INTERFACES
             value: ""
           - name: EXCLUDE_INTERFACES

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -28,7 +28,7 @@ spec:
           - name: METRICS_ENABLE
             value: "false"
           - name: LOG_LEVEL
-            value: trace
+            value: info
           - name: ENABLE_PCA
             value: "true"
           - name: FILTER_DIRECTION

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -137,6 +137,26 @@ function cleanup {
   fi
 }
 
+function common_usage {
+  echo "          --direction: flow filter direction"
+  echo "          --cidr: flow filter CIDR (default: 0.0.0.0/0)"
+  echo "          --protocol: flow filter protocol"
+  echo "          --sport: flow filter source port"
+  echo "          --dport: flow filter destination port"
+  echo "          --port: flow filter port"
+  echo "          --sport_range: flow filter source port range"
+  echo "          --dport_range: flow filter destination port range"
+  echo "          --port_range: flow filter port range"
+  echo "          --icmp_type: ICMP type"
+  echo "          --icmp_code: ICMP code"
+  echo "          --peer_ip: peer IP"
+  echo "          --action: flow filter action (default: Accept)"
+  echo "          --log-level: components logs (default: info)"
+  echo "          --max-time: maximum capture time (default: 5m)"
+  echo "          --max-bytes: maximum capture bytes (default: 50000000 = 50MB)"
+
+}
+
 function flows_usage {
   echo "        Options:"
   echo "          --interfaces: interfaces to monitor"
@@ -144,36 +164,12 @@ function flows_usage {
   echo "          --enable_dns: enable DNS tracking (default: false)"
   echo "          --enable_rtt: enable RTT tracking (default: false)"
   echo "          --enable_filter: enable flow filter (default: false)"
-  echo "          --direction: flow filter direction"
-  echo "          --cidr: flow filter CIDR (default: 0.0.0.0/0)"
-  echo "          --protocol: flow filter protocol"
-  echo "          --sport: flow filter source port"
-  echo "          --dport: flow filter destination port"
-  echo "          --port: flow filter port"
-  echo "          --sport_range: flow filter source port range"
-  echo "          --dport_range: flow filter destination port range"
-  echo "          --port_range: flow filter port range"
-  echo "          --icmp_type: ICMP type"
-  echo "          --icmp_code: ICMP code"
-  echo "          --peer_ip: peer IP"
-  echo "          --action: flow filter action (default: Accept)"
+  common_usage
 }
 
 function packets_usage {
   echo "        Options:"
-  echo "          --direction: flow filter direction"
-  echo "          --cidr: flow filter CIDR (default: 0.0.0.0/0)"
-  echo "          --protocol: flow filter protocol"
-  echo "          --sport: flow filter source port"
-  echo "          --dport: flow filter destination port"
-  echo "          --port: flow filter port"
-  echo "          --sport_range: flow filter source port range"
-  echo "          --dport_range: flow filter destination port range"
-  echo "          --port_range: flow filter port range"
-  echo "          --icmp_type: ICMP type"
-  echo "          --icmp_code: ICMP code"
-  echo "          --peer_ip: peer IP"
-  echo "          --action: flow filter action (default: Accept)"
+  common_usage
 }
 
 function edit_manifest() {
@@ -233,6 +229,9 @@ function edit_manifest() {
     ;;
   "filter_action")
     yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_ACTION\").value|=\"$2\"" "$3"
+    ;;
+  "log_level")
+    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"LOG_LEVEL\").value|=\"$2\"" "$3"
     ;;
   esac
 }
@@ -348,6 +347,23 @@ function check_args_and_apply() {
                 else
                   echo "invalid value for --action"
                 fi
+                ;;
+            --log-level) # Log level
+                if [[ "$value" == "trace" || "$value" == "debug" || "$value" == "info" || "$value" == "warn" || "$value" == "error" || "$value" == "fatal" || "$value" == "panic" ]]; then
+                  edit_manifest "log_level" "$value" "$2"
+                  logLevel=$value
+                  filter=${filter/$key=$logLevel/}
+                else
+                  echo "invalid value for --action"
+                fi
+                ;;
+            --max-time) # Max time
+                maxTime=$value
+                filter=${filter/$key=$maxTime/}
+                ;;
+            --max-bytes) # Max bytes
+                maxBytes=$value
+                filter=${filter/$key=$maxBytes/}
                 ;;
             *) # Invalid option
                 echo "Invalid option: $key" >&2


### PR DESCRIPTION
## Description

Auto teardown after some time / number of flows / packets
Also took the opportunity to add log level argument and improve display

```
oc netobserv flows --max-time=30s --max-bytes=1000000 --log-level=trace --sport=443 --direction=Ingress
```

```
Running network-observability-cli as Flow Capture
Log level: trace Duration: 28s Capture size: 116KB
Filters:    sport=443 direction=Ingress
```

```
          --log-level: components logs (default: info)
          --max-time: maximum capture time (default: 5m)
          --max-bytes: maximum capture bytes (default: 50000000 = 50MB)
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
