### PR TITLE
NETOBSERV-1693 Prompt for copying files on exit

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -3,6 +3,11 @@ source "./scripts/functions.sh"
 
 set +u
 
+# e2e skips inputs
+if [ -z "${isE2E+x}" ]; then isE2E=false; fi
+# keep capture state
+if [ -z "${captureStarted+x}" ]; then captureStarted=false; fi
+
 # interface filter such as 'br-ex' or pcap filter such as 'tcp,80'
 filter=""
 
@@ -76,7 +81,9 @@ ${K8S_CLI_BIN} run \
 
 ${K8S_CLI_BIN} wait \
   -n netobserv-cli \
-  --for=condition=Ready pod/collector
+  --for=condition=Ready pod/collector || exit 1
+
+captureStarted=true
 
 ${K8S_CLI_BIN} exec -i --tty \
   -n netobserv-cli \

--- a/e2e/common.go
+++ b/e2e/common.go
@@ -24,6 +24,7 @@ func RunCommand(log *logrus.Entry, commandName string, arg ...string) ([]byte, e
 
 	log.Print("Executing command...")
 	cmd := exec.Command(cmdStr, arg...)
+	cmd.Env = append(cmd.Environ(), "isE2E=true")
 
 	timer := time.AfterFunc(CommandTimeout, func() {
 		log.Print("Terminating command...")


### PR DESCRIPTION
## Description

Ask for copy on exit

```
INFO[0034] Ctrl-C pressed, exiting program.             
kubernetes-admin
Copy the capture output locally ?y
Copying collector output files...

Cleaning up... namespace "netobserv-cli" deleted
```

```
INFO[0004] Ctrl-C pressed, exiting program.             
kubernetes-admin
Copy the capture output locally ?n
copy skipped

Cleaning up... namespace "netobserv-cli" deleted
```

The total capture size will be displayed in https://github.com/netobserv/network-observability-cli/pull/59

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
