### PR TITLE
NETOBSERV-1749: fix flows and packets arg processing

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -108,7 +108,7 @@ function setup {
     manifest="${MANIFEST_OUTPUT_PATH}/${FLOWS_MANIFEST_FILE}"
     echo "${flowAgentYAML}" > ${manifest}
     options="$*"
-    check_args_and_apply "$options" "$manifest" "$1"
+    check_args_and_apply "$options" "$manifest" "flows"
   elif [ "$1" = "packets" ]; then
     shift
     echo "creating packet-capture agents"
@@ -118,7 +118,7 @@ function setup {
     manifest="${MANIFEST_OUTPUT_PATH}/${PACKETS_MANIFEST_FILE}"
     echo "${packetAgentYAML}" > ${manifest}
     options="$*"
-    check_args_and_apply "$options" "$manifest" "$1"
+    check_args_and_apply "$options" "$manifest" "packets"
   fi
 }
 


### PR DESCRIPTION
## Description

fix a bug introduced when shared args processing between packets and flows in #54 
after `shift` command the position of arguments will change
## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
