### PR TITLE
NETOBSERV-1693 Prompt for copying files on exit followup

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -7,6 +7,8 @@ set +u
 if [ -z "${isE2E+x}" ]; then isE2E=false; fi
 # keep capture state
 if [ -z "${captureStarted+x}" ]; then captureStarted=false; fi
+# prompt copy by default
+if [ -z "${copy+x}" ]; then copy="prompt"; fi
 
 # interface filter such as 'br-ex' or pcap filter such as 'tcp,80'
 filter=""

--- a/docs/netobserv_cli_flows_config.md
+++ b/docs/netobserv_cli_flows_config.md
@@ -17,6 +17,15 @@ USER=netobserv make commands
 ./build/oc-netobserv flows --enable_pktdrop=true  --enable_rtt=true --enable_filter=true --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
 ```
 
+- The following table show general options.
+
+| Option          | Description                                 | Possible values                                  | Default   |
+|-----------------|---------------------------------------------|--------------------------------------------------|-----------|
+| --log-level     | Components logs                             | for example debug or trace                       | info      |
+| --max-time      | Maximum capture time                        | for example 10m or 30s                           | 5m        |
+| --max-bytes     | Maximum capture bytes                       | for example 10000000 (1MB)                       | 50000000  |
+| --copy          | Copy the output files locally               | for example prompt, yes or no                    | prompt    |
+
 - The following table shows all supported features options.
 
 | Option           | Description                     | Possible values   | Default |
@@ -44,6 +53,3 @@ USER=netobserv make commands
 | --icmp_type     | ICMP type to match on the flow              | for example 8 or 13                              | no        |           |
 | --icmp_code     | ICMP code to match on the flow              | for example 0 or 1                               | no        |           |
 | --peer_ip       | Peer IP to match on the flow                | for example 1.1.1.1 or 1::1                      | no        |           |
-| --log-level     | Components logs                             | for example debug or trace                       | no        | info      |
-| --max-time      | Maximum capture time                        | for example 10m or 30s                           | no        | 5m        |
-| --max-bytes     | max-bytes: maximum capture bytes            | for example 10000000 (1MB)                       | no        | 50000000  |

--- a/docs/netobserv_cli_packets_config.md
+++ b/docs/netobserv_cli_packets_config.md
@@ -17,6 +17,15 @@ USER=netobserv make commands
 ./build/oc-netobserv packets --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
 ```
 
+- The following table show general options.
+
+| Option          | Description                                 | Possible values                                  | Default   |
+|-----------------|---------------------------------------------|--------------------------------------------------|-----------|
+| --log-level     | Components logs                             | for example debug or trace                       | info      |
+| --max-time      | Maximum capture time                        | for example 10m or 30s                           | 5m        |
+| --max-bytes     | Maximum capture bytes                       | for example 10000000 (1MB)                       | 50000000  |
+| --copy          | Copy the output files locally               | for example prompt, yes or no                    | prompt    |
+
 - The following table shows filter configuration options.
 
 | Option          | Description                                 | Possible values                                  | Mandatory | Default   |
@@ -34,6 +43,3 @@ USER=netobserv make commands
 | --icmp_type     | ICMP type to match on the flow              | for example 8 or 13                              | no        |           |
 | --icmp_code     | ICMP code to match on the flow              | for example 0 or 1                               | no        |           |
 | --peer_ip       | Peer IP to match on the flow                | for example 1.1.1.1 or 1::1                      | no        |           |
-| --log-level     | Components logs                             | for example debug or trace                       | no        | info      |
-| --max-time      | Maximum capture time                        | for example 10m or 30s                           | no        | 5m        |
-| --max-bytes     | max-bytes: maximum capture bytes            | for example 10000000 (1MB)                       | no        | 50000000  |

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -162,6 +162,12 @@ function cleanup {
 }
 
 function common_usage {
+  # general options
+  echo "          --log-level: components logs (default: info)"
+  echo "          --max-time: maximum capture time (default: 5m)"
+  echo "          --max-bytes: maximum capture bytes (default: 50000000 = 50MB)"
+  echo "          --copy: copy the output files locally (default: prompt)"
+  # filters
   echo "          --direction: flow filter direction"
   echo "          --cidr: flow filter CIDR (default: 0.0.0.0/0)"
   echo "          --protocol: flow filter protocol"
@@ -175,24 +181,26 @@ function common_usage {
   echo "          --icmp_code: ICMP code"
   echo "          --peer_ip: peer IP"
   echo "          --action: flow filter action (default: Accept)"
-  echo "          --log-level: components logs (default: info)"
-  echo "          --max-time: maximum capture time (default: 5m)"
-  echo "          --max-bytes: maximum capture bytes (default: 50000000 = 50MB)"
 
 }
 
 function flows_usage {
   echo "        Options:"
-  echo "          --interfaces: interfaces to monitor"
+  # features
   echo "          --enable_pktdrop: enable packet drop (default: false)"
   echo "          --enable_dns: enable DNS tracking (default: false)"
   echo "          --enable_rtt: enable RTT tracking (default: false)"
   echo "          --enable_filter: enable flow filter (default: false)"
+  # common
   common_usage
+  # specific filters
+  echo "          --interfaces: interfaces to monitor"
+
 }
 
 function packets_usage {
   echo "        Options:"
+  # common
   common_usage
 }
 
@@ -272,6 +280,7 @@ function check_args_and_apply() {
         case "$key" in
             --copy) # Copy or skip without prompt
                 if [[ "$value" == "true" || "$value" == "false" || "$value" == "prompt" ]]; then
+                  echo "param: $key, param_value: $value"
                   copy="$value"
                 else
                   echo "invalid value for --copy"
@@ -389,10 +398,12 @@ function check_args_and_apply() {
                 fi
                 ;;
             --max-time) # Max time
+                echo "param: $key, param_value: $value"
                 maxTime=$value
                 filter=${filter/$key=$maxTime/}
                 ;;
             --max-bytes) # Max bytes
+                echo "param: $key, param_value: $value"
                 maxBytes=$value
                 filter=${filter/$key=$maxBytes/}
                 ;;


### PR DESCRIPTION
## Description

@Amoghrd would that work for you ?

```
--copy=true|false|prompt
```

by default the `prompt` is asked at the end of the collection. If the user specify `--copy=true` or `--copy=false`, the corresponding action is done without prompt.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
