### PR TITLE
NETOBSERV-1627 Add commands to image for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,23 @@ COPY cmd cmd
 COPY main.go main.go
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY commands/ commands/
+COPY res/ res/
+COPY scripts/ scripts/
 COPY vendor/ vendor/
 COPY Makefile Makefile
 COPY .mk/ .mk/
 
-# Build
+# Build collector
 RUN GOARCH=$TARGETARCH make compile
+
+# Embedd commands in case users want to pull it from collector image
+RUN USER=netobserv VERSION=main make oc-commands
+
 # Prepare output dir
 RUN mkdir -p output
 
-# Create final image from ubi + built binary
+# Create final image from ubi + built binary and command
 FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9-minimal:9.4
 RUN microdnf update -y && microdnf install -y tar
 WORKDIR /


### PR DESCRIPTION
## Description

Add `oc-commands` output to collector image to easy get it from CI.
This could also be usefull for users having the container image but not the script installed locally :) 

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
