### PR TITLE
NETOBSERV-1803: Allow flow filtering for L4 protocols using two ports

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -63,6 +63,12 @@ spec:
             value: ""
           - name: FILTER_PORT_RANGE
             value: ""
+          - name:  FILTER_SOURCE_PORTS
+            value: ""
+          - name: FILTER_DESTINATION_PORTS
+            value: ""
+          - name: FILTER_PORTS
+            value: ""
           - name: FILTER_ICMP_TYPE
             value: ""
           - name: FILTER_ICMP_CODE

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -49,6 +49,12 @@ spec:
             value: ""
           - name: FILTER_PORT_RANGE
             value: ""
+          - name:  FILTER_SOURCE_PORTS
+            value: ""
+          - name: FILTER_DESTINATION_PORTS
+            value: ""
+          - name: FILTER_PORTS
+            value: ""
           - name: FILTER_ICMP_TYPE
             value: ""
           - name: FILTER_ICMP_CODE

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -168,21 +168,23 @@ function common_usage {
   echo "          --max-bytes:        maximum capture bytes               (default: 50000000 = 50MB)"
   echo "          --copy:             copy the output files locally       (default: prompt)"
   # filters
-  echo "          --direction:        flow filter direction               (default: n/a)"
-  echo "          --cidr:             flow filter CIDR                    (default: 0.0.0.0/0)"
-  echo "          --protocol:         flow filter protocol                (default: n/a)"
-  echo "          --sport:            flow filter source port             (default: n/a)"
-  echo "          --dport:            flow filter destination port        (default: n/a)"
-  echo "          --port:             flow filter port                    (default: n/a)"
-  echo "          --sport_range:      flow filter source port range       (default: n/a)"
-  echo "          --dport_range:      flow filter destination port range  (default: n/a)"
-  echo "          --port_range:       flow filter port range              (default: n/a)"
-  echo "          --tcp_flags:        flow filter TCP flags               (default: n/a)"
-  echo "          --icmp_type:        ICMP type                           (default: n/a)"
-  echo "          --icmp_code:        ICMP code                           (default: n/a)"
-  echo "          --peer_ip:          peer IP                             (default: n/a)"
-  echo "          --action:           flow filter action                  (default: Accept)"
-
+  echo "          --direction:        flow filter direction                           (default: n/a)"
+  echo "          --cidr:             flow filter CIDR                                (default: 0.0.0.0/0)"
+  echo "          --protocol:         flow filter protocol                            (default: n/a)"
+  echo "          --sport:            flow filter source port                         (default: n/a)"
+  echo "          --dport:            flow filter destination port                    (default: n/a)"
+  echo "          --port:             flow filter port                                (default: n/a)"
+  echo "          --sport_range:      flow filter source port range                   (default: n/a)"
+  echo "          --dport_range:      flow filter destination port range              (default: n/a)"
+  echo "          --port_range:       flow filter port range                          (default: n/a)"
+  echo "          --sports:           flow filter on either of two source ports       (default: n/a)"
+  echo "          --dports:           flow filter on either of two destination ports  (default: n/a)"
+  echo "          --ports:            flow filter on either of two ports              (default: n/a)"
+  echo "          --tcp_flags:        flow filter TCP flags                           (default: n/a)"
+  echo "          --icmp_type:        ICMP type                                       (default: n/a)"
+  echo "          --icmp_code:        ICMP code                                       (default: n/a)"
+  echo "          --peer_ip:          peer IP                                         (default: n/a)"
+  echo "          --action:           flow filter action                              (default: Accept)"
 }
 
 function flows_usage {
@@ -252,6 +254,15 @@ function edit_manifest() {
     ;;
   "filter_port_range")
     yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PORT_RANGE\").value|=\"$2\"" "$3"
+    ;;
+  "filter_sports")
+    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_SOURCE_PORTS\").value|=\"$2\"" "$3"
+    ;;
+  "filter_dportS")
+    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DESTINATION_PORTS\").value|=\"$2\"" "$3"
+    ;;
+  "filter_ports")
+    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PORTS\").value|=\"$2\"" "$3"
     ;;
   "filter_icmp_type")
     yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_ICMP_TYPE\").value|=\"$2\"" "$3"
@@ -389,6 +400,15 @@ function check_args_and_apply() {
                 ;;
             --port_range) # Configure filter port range
                 edit_manifest "filter_port_range" "$value" "$2"
+                ;;
+            --sports) # Configure filter source two ports using ","
+                edit_manifest "filter_sports" "$value" "$2"
+                ;;
+            --dports) # Configure filter destination two ports using ","
+                edit_manifest "filter_dports" "$value" "$2"
+                ;;
+            --ports) # Configure filter on two ports usig "," can either be srcport or dstport
+                edit_manifest "filter_ports" "$value" "$2"
                 ;;
             --tcp_flags) # Configure filter TCP flags
               if [[ "$value" == "SYN" || "$value" == "SYN-ACK" || "$value" == "ACK" || "$value" == "FIN" || "$value" == "RST" || "$value" == "FIN-ACK" || "$value" == "RST-ACK" || "$value" == "PSH" || "$value" == "URG" || "$value" == "ECE" || "$value" == "CWR" ]]; then


### PR DESCRIPTION
## Description

Allow filtering TCP/UDP/SCTP using two ports syntax like "90,100" to filter either on port 90 or 100


## Dependencies
https://github.com/netobserv/netobserv-ebpf-agent/pull/389

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
