### PR TITLE
NETOBSERV-1850 fix cli enrichment issue

### DIFF
--- a/cmd/packet_capture.go
+++ b/cmd/packet_capture.go
@@ -27,12 +27,6 @@ var pktCmd = &cobra.Command{
 	Run:   runPacketCapture,
 }
 
-type PcapResult struct {
-	Name        string
-	PacketCount int64
-	ByteCount   int64
-}
-
 func runPacketCapture(_ *cobra.Command, _ []string) {
 	go scanner()
 
@@ -146,8 +140,8 @@ func runPacketCaptureOnAddr(port int, filename string) {
 			// write enriched data as interface
 			writeEnrichedData(pw, &genericMap)
 
-			// then append packet to file
-			err = pw.WriteEnhancedPacketBlock(0, ts, b, types.EnhancedPacketOptions{})
+			// then append packet to file using totalPackets as unique id
+			err = pw.WriteEnhancedPacketBlock(totalPackets, ts, b, types.EnhancedPacketOptions{})
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -166,6 +160,7 @@ func runPacketCaptureOnAddr(port int, filename string) {
 			log.Infof("Capture reached %s, exiting now...", sizestr.ToString(maxBytes))
 			return
 		}
+		totalPackets = totalPackets + 1
 
 		// terminate capture if max time reached
 		now := currentTime()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,9 +31,10 @@ var (
 	currentTime = func() time.Time {
 		return time.Now()
 	}
-	startupTime = currentTime()
-	lastRefresh = startupTime
-	totalBytes  = int64(0)
+	startupTime  = currentTime()
+	lastRefresh  = startupTime
+	totalBytes   = int64(0)
+	totalPackets = uint32(0)
 
 	mutex = sync.Mutex{}
 


### PR DESCRIPTION
## Description

Fix CLI packet enrichment issue where all packets were pointing the same info

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
