### PR TITLE
OSDOCS-11821 help & doc cleanup

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -71,13 +71,13 @@ case "$1" in
     echo
     echo "Syntax: netobserv [flows|packets|cleanup] [options]"
     echo
-    echo "options:"
+    echo "commands:"
     echo "  flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'."
     echo "        Options:"
     flows_usage
     echo "  packets    Capture packets information in pcap format."
-    packets_usage
     echo "        Options:"
+    packets_usage
     echo "  cleanup    Remove netobserv components."
     echo "  version    Print software version."
     echo

--- a/docs/netobserv_cli.adoc
+++ b/docs/netobserv_cli.adoc
@@ -22,7 +22,7 @@ $ oc netobserv [<command>] [<feature_option>] [<command_options>] <1>
 | flows
 | Capture flows information. For subcommands, see the "Flow capture subcommands" table.
 | packets
-| Capture packets from a specific protocol or port pair, such as netobserv packets --filter=tcp,80. For more information about packet capture, see the "Packet capture subcommand" table.
+| Capture packets data. For subcommands, see the "Packet capture subcommand" table.
 | cleanup
 | Remove the Network Observability CLI components.
 | version
@@ -41,32 +41,36 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 [cols="1,1,1",options="header"]
 |===
 | Option | Description | Default
-|--enable_pktdrop|  enable packet drop                  | false
-|--enable_dns|      enable DNS tracking                 | false
-|--enable_rtt|      enable RTT tracking                 | false
-|--enable_filter|   enable flow filter                  | false
-|--log-level|       components logs                     | info
-|--max-time|        maximum capture time                | 5m
-|--max-bytes|       maximum capture bytes               | 50000000 = 50MB
-|--copy|            copy the output files locally       | prompt
-|--direction|       flow filter direction               | n/a
-|--cidr|            flow filter CIDR                    | 0.0.0.0/0
-|--protocol|        flow filter protocol                | n/a
-|--sport|           flow filter source port             | n/a
-|--dport|           flow filter destination port        | n/a
-|--port|            flow filter port                    | n/a
-|--sport_range|     flow filter source port range       | n/a
-|--dport_range|     flow filter destination port range  | n/a
-|--port_range|      flow filter port range              | n/a
-|--tcp_flags|       flow filter TCP flags               | n/a
-|--icmp_type|       ICMP type                           | n/a
-|--icmp_code|       ICMP code                           | n/a
-|--peer_ip|         peer IP                             | n/a
-|--action|          flow filter action                  | Accept
-|--interfaces|      interfaces to monitor               | n/a
+|--enable_pktdrop|        enable packet drop                         | false
+|--enable_dns|            enable DNS tracking                        | false
+|--enable_rtt|            enable RTT tracking                        | false
+|--enable_network_events| enable Network events monitoring           | false
+|--enable_filter|         enable flow filter                         | false
+|--log-level|             components logs                            | info
+|--max-time|              maximum capture time                       | 5m
+|--max-bytes|             maximum capture bytes                      | 50000000 = 50MB
+|--copy|                  copy the output files locally              | prompt
+|--direction|             filter direction                           | n/a
+|--cidr|                  filter CIDR                                | 0.0.0.0/0
+|--protocol|              filter protocol                            | n/a
+|--sport|                 filter source port                         | n/a
+|--dport|                 filter destination port                    | n/a
+|--port|                  filter port                                | n/a
+|--sport_range|           filter source port range                   | n/a
+|--dport_range|           filter destination port range              | n/a
+|--port_range|            filter port range                          | n/a
+|--sports|                filter on either of two source ports       | n/a
+|--dports|                filter on either of two destination ports  | n/a
+|--ports|                 filter on either of two ports              | n/a
+|--tcp_flags|             filter TCP flags                           | n/a
+|--action|                filter action                              | Accept
+|--icmp_type|             filter ICMP type                           | n/a
+|--icmp_code|             filter ICMP code                           | n/a
+|--peer_ip|               filter peer IP                             | n/a
+|--interfaces|            interfaces to monitor                      | n/a
 |===
 
-.Example running flow capture with options:
+.Example running flow capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
 [source,terminal]
 ----
 $ oc netobserv flows --enable_pktdrop=true  --enable_rtt=true --enable_filter=true --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
@@ -82,27 +86,30 @@ $ oc netobserv packets [<option>]
 [cols="1,1,1",options="header"]
 |===
 | Option | Description | Default
-|--log-level|       components logs                     | info
-|--max-time|        maximum capture time                | 5m
-|--max-bytes|       maximum capture bytes               | 50000000 = 50MB
-|--copy|            copy the output files locally       | prompt
-|--direction|       flow filter direction               | n/a
-|--cidr|            flow filter CIDR                    | 0.0.0.0/0
-|--protocol|        flow filter protocol                | n/a
-|--sport|           flow filter source port             | n/a
-|--dport|           flow filter destination port        | n/a
-|--port|            flow filter port                    | n/a
-|--sport_range|     flow filter source port range       | n/a
-|--dport_range|     flow filter destination port range  | n/a
-|--port_range|      flow filter port range              | n/a
-|--tcp_flags|       flow filter TCP flags               | n/a
-|--icmp_type|       ICMP type                           | n/a
-|--icmp_code|       ICMP code                           | n/a
-|--peer_ip|         peer IP                             | n/a
-|--action|          flow filter action                  | Accept
+|--log-level|             components logs                            | info
+|--max-time|              maximum capture time                       | 5m
+|--max-bytes|             maximum capture bytes                      | 50000000 = 50MB
+|--copy|                  copy the output files locally              | prompt
+|--direction|             filter direction                           | n/a
+|--cidr|                  filter CIDR                                | 0.0.0.0/0
+|--protocol|              filter protocol                            | n/a
+|--sport|                 filter source port                         | n/a
+|--dport|                 filter destination port                    | n/a
+|--port|                  filter port                                | n/a
+|--sport_range|           filter source port range                   | n/a
+|--dport_range|           filter destination port range              | n/a
+|--port_range|            filter port range                          | n/a
+|--sports|                filter on either of two source ports       | n/a
+|--dports|                filter on either of two destination ports  | n/a
+|--ports|                 filter on either of two ports              | n/a
+|--tcp_flags|             filter TCP flags                           | n/a
+|--action|                filter action                              | Accept
+|--icmp_type|             filter ICMP type                           | n/a
+|--icmp_code|             filter ICMP code                           | n/a
+|--peer_ip|               filter peer IP                             | n/a
 |===
 
-.Example running packet capture with options:
+.Example running packet capture on TCP protocol and port 49051:
 [source,terminal]
 ----
 $ oc netobserv packets --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -163,41 +163,41 @@ function cleanup {
 
 function common_usage {
   # general options
-  echo "          --log-level:        components logs                     (default: info)"
-  echo "          --max-time:         maximum capture time                (default: 5m)"
-  echo "          --max-bytes:        maximum capture bytes               (default: 50000000 = 50MB)"
-  echo "          --copy:             copy the output files locally       (default: prompt)"
+  echo "          --log-level:              components logs                            (default: info)"
+  echo "          --max-time:               maximum capture time                       (default: 5m)"
+  echo "          --max-bytes:              maximum capture bytes                      (default: 50000000 = 50MB)"
+  echo "          --copy:                   copy the output files locally              (default: prompt)"
   # filters
-  echo "          --direction:        flow filter direction                           (default: n/a)"
-  echo "          --cidr:             flow filter CIDR                                (default: 0.0.0.0/0)"
-  echo "          --protocol:         flow filter protocol                            (default: n/a)"
-  echo "          --sport:            flow filter source port                         (default: n/a)"
-  echo "          --dport:            flow filter destination port                    (default: n/a)"
-  echo "          --port:             flow filter port                                (default: n/a)"
-  echo "          --sport_range:      flow filter source port range                   (default: n/a)"
-  echo "          --dport_range:      flow filter destination port range              (default: n/a)"
-  echo "          --port_range:       flow filter port range                          (default: n/a)"
-  echo "          --sports:           flow filter on either of two source ports       (default: n/a)"
-  echo "          --dports:           flow filter on either of two destination ports  (default: n/a)"
-  echo "          --ports:            flow filter on either of two ports              (default: n/a)"
-  echo "          --tcp_flags:        flow filter TCP flags                           (default: n/a)"
-  echo "          --icmp_type:        ICMP type                                       (default: n/a)"
-  echo "          --icmp_code:        ICMP code                                       (default: n/a)"
-  echo "          --peer_ip:          peer IP                                         (default: n/a)"
-  echo "          --action:           flow filter action                              (default: Accept)"
+  echo "          --direction:              filter direction                           (default: n/a)"
+  echo "          --cidr:                   filter CIDR                                (default: 0.0.0.0/0)"
+  echo "          --protocol:               filter protocol                            (default: n/a)"
+  echo "          --sport:                  filter source port                         (default: n/a)"
+  echo "          --dport:                  filter destination port                    (default: n/a)"
+  echo "          --port:                   filter port                                (default: n/a)"
+  echo "          --sport_range:            filter source port range                   (default: n/a)"
+  echo "          --dport_range:            filter destination port range              (default: n/a)"
+  echo "          --port_range:             filter port range                          (default: n/a)"
+  echo "          --sports:                 filter on either of two source ports       (default: n/a)"
+  echo "          --dports:                 filter on either of two destination ports  (default: n/a)"
+  echo "          --ports:                  filter on either of two ports              (default: n/a)"
+  echo "          --tcp_flags:              filter TCP flags                           (default: n/a)"
+  echo "          --action:                 filter action                              (default: Accept)"
+  echo "          --icmp_type:              filter ICMP type                           (default: n/a)"
+  echo "          --icmp_code:              filter ICMP code                           (default: n/a)"
+  echo "          --peer_ip:                filter peer IP                             (default: n/a)"
 }
 
 function flows_usage {
   # features
-  echo "          --enable_pktdrop:   enable packet drop                    (default: false)"
-  echo "          --enable_dns:       enable DNS tracking                   (default: false)"
-  echo "          --enable_rtt:       enable RTT tracking                   (default: false)"
-  echo "          --enable_network_events: enable Network events Monitoring (default: false)"
-  echo "          --enable_filter:    enable flow filter                    (default: false)"
+  echo "          --enable_pktdrop:         enable packet drop                         (default: false)"
+  echo "          --enable_dns:             enable DNS tracking                        (default: false)"
+  echo "          --enable_rtt:             enable RTT tracking                        (default: false)"
+  echo "          --enable_network_events:  enable Network events monitoring           (default: false)"
+  echo "          --enable_filter:          enable flow filter                         (default: false)"
   # common
   common_usage
   # specific filters
-  echo "          --interfaces:       interfaces to monitor               (default: n/a)"
+  echo "          --interfaces:             interfaces to monitor                      (default: n/a)"
 
 }
 

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -26,7 +26,7 @@ $ oc netobserv [<command>] [<feature_option>] [<command_options>] <1>
 | flows
 | Capture flows information. For subcommands, see the \"Flow capture subcommands\" table.
 | packets
-| Capture packets from a specific protocol or port pair, such as netobserv packets --filter=tcp,80. For more information about packet capture, see the \"Packet capture subcommand\" table.
+| Capture packets data. For subcommands, see the \"Packet capture subcommand\" table.
 | cleanup
 | Remove the Network Observability CLI components.
 | version
@@ -52,7 +52,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 echo -e "|==="
 # Flow example
 echo "
-.Example running flow capture with options:
+.Example running flow capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
 [source,terminal]
 ----
 $ oc netobserv flows --enable_pktdrop=true  --enable_rtt=true --enable_filter=true --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
@@ -74,7 +74,7 @@ $ oc netobserv packets [<option>]
 echo -e "|==="
 # Packet example
 echo "
-.Example running packet capture with options:
+.Example running packet capture on TCP protocol and port 49051:
 [source,terminal]
 ----
 $ oc netobserv packets --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051


### PR DESCRIPTION
## Description

Polishing generated doc from https://github.com/openshift/openshift-docs/pull/81064 feedback

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
