### PR TITLE
NETOBSERV-1633: Fix multiarch build with new buildah version

### DIFF
--- a/.tekton/network-observability-cli-container-pull-request.yaml
+++ b/.tekton/network-observability-cli-container-pull-request.yaml
@@ -94,7 +94,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -397,28 +397,6 @@ spec:
           value: clamav-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:a5742024c2755d3636110aea0b86d298660bb8b7708894674baec16bb90b7106
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:acc9cb8a714f33c0e48d6ca219b6bd0191f09cdd767af4ef3a35d0a5cac53b5d
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/network-observability-cli-container-push.yaml
+++ b/.tekton/network-observability-cli-container-push.yaml
@@ -91,7 +91,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string
@@ -394,28 +394,6 @@ spec:
           value: clamav-scan
         - name: bundle
           value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:a5742024c2755d3636110aea0b86d298660bb8b7708894674baec16bb90b7106
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sbom-json-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-container.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.1@sha256:acc9cb8a714f33c0e48d6ca219b6bd0191f09cdd767af4ef3a35d0a5cac53b5d
         - name: kind
           value: task
         resolver: bundles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
-ARG TARGETPLATFORM=linux/amd64
-ARG BUILDPLATFORM=linux/amd64
 ARG TARGETARCH=amd64
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.22 as builder
 
 ARG TARGETARCH
 ARG TARGETPLATFORM
@@ -33,7 +31,7 @@ RUN USER=netobserv VERSION=main make oc-commands
 RUN mkdir -p output
 
 # Create final image from ubi + built binary and command
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi:9.4
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi:9.4
 WORKDIR /
 COPY --from=builder /opt/app-root/build .
 COPY --from=builder --chown=65532:65532 /opt/app-root/output /output

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MULTIARCH_TARGETS ?= amd64
 # In CI, to be replaced by `netobserv`
 IMAGE_ORG ?= $(USER)
 
-# Build output 
+# Build output
 NAME := network-observability-cli
 DIST_DIR ?= build
 FILES_OUTPUT_DIR ?= output
@@ -31,7 +31,7 @@ OUTPUT := $(DIST_DIR)/$(NAME)
 
 # Available commands for development with args
 COMMANDS = flows packets cleanup
-COMMAND_ARGS ?= 
+COMMAND_ARGS ?=
 
 # Get either oc (favorite) or kubectl paths
 K8S_CLI_BIN_PATH = $(shell which oc 2>/dev/null || which kubectl)
@@ -58,7 +58,7 @@ YQ_VERSION = v4.43.1
 # build a single arch target provided as argument
 define build_target
 	echo 'building image for arch $(1)'; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETPLATFORM=linux/$(1) --build-arg TARGETARCH=$(1) --build-arg BUILDPLATFORM=linux/amd64 ${OCI_BUILD_OPTS} -t ${IMAGE}-$(1) -f Dockerfile .;
+	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETARCH=$(1) ${OCI_BUILD_OPTS} -t ${IMAGE}-$(1) -f Dockerfile .;
 endef
 
 # push a single arch target image


### PR DESCRIPTION
## Description

Address error in buildah build and also enable hermetic build which is a downstream requirement.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
