### PR TITLE
NETOBSERV-1906 add nodeSelector

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -158,7 +158,6 @@ spec:
             - name: var-run-ovs
               mountPath: /var/run/openvswitch
               mountPropagation: Bidirectional
-
       volumes:
         - name: bpf-kernel-debug
           hostPath:

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -136,7 +136,6 @@ spec:
             - name: bpf-kernel-debug
               mountPath: /sys/kernel/debug
               mountPropagation: Bidirectional
-
       volumes:
         - name: bpf-kernel-debug
           hostPath:

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -289,8 +289,9 @@ function edit_manifest() {
     yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"LOG_LEVEL\").value|=\"$2\"" "$3"
     ;;
   "node_selector")
-    keyVal=(${2//:/ })
-    yq e --inplace ".spec.template.spec.nodeSelector.\""${keyVal[0]}"\" |= \""${keyVal[1]}"\"" "$3"
+    key=${2%:*}
+    val=${2#*:}
+    yq e --inplace ".spec.template.spec.nodeSelector.\"$key\" |= \"$val\"" "$3"
     ;;
   esac
 }


### PR DESCRIPTION
## Description

Add option to set a single node selector to eBPF agents.
```
$ ./build/oc-netobserv flows --node-selector=kubernetes.io/hostname:netobserv-cli-cluster-worker
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
