### PR TITLE
NETOBSERV-1907 run in background

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,14 @@ COPY res/ res/
 COPY scripts/ scripts/
 COPY Makefile Makefile
 COPY .mk/ .mk/
-# Embed commands in case users want to pull it from collector image
+
+# Install oc to allow collector to run commands
+RUN set -x; \
+    OC_TAR_URL="https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/latest/openshift-client-linux.tar.gz" && \
+    curl -L -q -o /tmp/oc.tar.gz "$OC_TAR_URL" && \
+    tar -C /tmp -xvf /tmp/oc.tar.gz oc kubectl
+
+# Embedd commands in case users want to pull it from collector image
 RUN USER=netobserv VERSION=main make oc-commands
 
 # Prepare output dir
@@ -34,15 +41,10 @@ RUN mkdir -p output
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi:9.4
 WORKDIR /
 
-# Install oc to allow collector to run commands
-RUN set -x; \
-    OC_TAR_URL="https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/latest/openshift-client-linux.tar.gz" && \
-    curl -L -q -o /tmp/oc.tar.gz "$OC_TAR_URL" && \
-    tar -C /usr/bin/ -xvf /tmp/oc.tar.gz oc && \
-    ln -sf /usr/bin/oc /usr/bin/kubectl && \
-    rm -f /tmp/oc.tar.gz
-
 COPY --from=builder /opt/app-root/build .
+COPY --from=builder /opt/app-root/build .
+COPY --from=builder /tmp/oc /usr/bin/oc
+COPY --from=builder /tmp/kubectl /usr/bin/kubectl
 COPY --from=builder --chown=65532:65532 /opt/app-root/output /output
 USER 65532:65532
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,15 @@ RUN mkdir -p output
 # Create final image from ubi + built binary and command
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi:9.4
 WORKDIR /
+
+# Install oc to allow collector to run commands
+RUN set -x; \
+    OC_TAR_URL="https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/clients/ocp/latest/openshift-client-linux.tar.gz" && \
+    curl -L -q -o /tmp/oc.tar.gz "$OC_TAR_URL" && \
+    tar -C /usr/bin/ -xvf /tmp/oc.tar.gz oc && \
+    ln -sf /usr/bin/oc /usr/bin/kubectl && \
+    rm -f /tmp/oc.tar.gz
+
 COPY --from=builder /opt/app-root/build .
 COPY --from=builder --chown=65532:65532 /opt/app-root/output /output
 USER 65532:65532

--- a/cmd/flow_capture.go
+++ b/cmd/flow_capture.go
@@ -159,7 +159,7 @@ func runFlowCaptureOnAddr(port int, filename string) {
 		duration := now.Sub(startupTime)
 		if int(duration) > int(maxTime) {
 			if exit := onLimitReached(); exit {
-				log.Infof("Capture reached %s, exiting now...", sizestr.ToString(maxBytes))
+				log.Infof("Capture reached %s, exiting now...", maxTime)
 				return
 			}
 		}

--- a/cmd/packet_capture.go
+++ b/cmd/packet_capture.go
@@ -158,8 +158,10 @@ func runPacketCaptureOnAddr(port int, filename string) {
 		// terminate capture if max bytes reached
 		totalBytes = totalBytes + int64(len(fp.GenericMap.Value))
 		if totalBytes > maxBytes {
-			log.Infof("Capture reached %s, exiting now...", sizestr.ToString(maxBytes))
-			return
+			if exit := onLimitReached(); exit {
+				log.Infof("Capture reached %s, exiting now...", sizestr.ToString(maxBytes))
+				return
+			}
 		}
 		totalPackets = totalPackets + 1
 
@@ -167,8 +169,10 @@ func runPacketCaptureOnAddr(port int, filename string) {
 		now := currentTime()
 		duration := now.Sub(startupTime)
 		if int(duration) > int(maxTime) {
-			log.Infof("Capture reached %s, exiting now...", maxTime)
-			return
+			if exit := onLimitReached(); exit {
+				log.Infof("Capture reached %s, exiting now...", maxTime)
+				return
+			}
 		}
 
 		captureStarted = true

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -73,7 +73,7 @@ func TestDefaultArguments(t *testing.T) {
 	assert.Equal(t, "info", logLevel)
 	assert.Equal(t, []int{9999}, ports)
 	assert.Equal(t, []string{""}, nodes)
-	assert.Empty(t, filter)
+	assert.Empty(t, options)
 }
 
 func setup() {

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -9,9 +9,11 @@ if [ -z "${isE2E+x}" ]; then isE2E=false; fi
 if [ -z "${captureStarted+x}" ]; then captureStarted=false; fi
 # prompt copy by default
 if [ -z "${copy+x}" ]; then copy="prompt"; fi
+# run foreground by default
+if [ -z "${runBackground+x}" ]; then runBackground="false"; fi
 
-# interface filter such as 'br-ex' or pcap filter such as 'tcp,80'
-filter=""
+# options such as filters, background etc
+options=""
 
 # CLI image to use
 img="quay.io/netobserv/network-observability-cli:main"
@@ -43,7 +45,7 @@ function flows() {
       exit 0 ;;
     *)
       shift # remove first argument
-      filter="$*"
+      options="$*"
       # run flows command
       command="flows" ;;
   esac
@@ -56,7 +58,7 @@ function packets() {
       exit 0 ;;
     *)
       shift # remove first argument
-      filter="$*"
+      options="$*"
       # run packets command
       command="packets" ;;
   esac
@@ -72,12 +74,15 @@ case "$1" in
     echo "Syntax: netobserv [flows|packets|cleanup] [options]"
     echo
     echo "commands:"
-    echo "  flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'."
+    echo "  flows      Capture flows information in JSON format."
     echo "        Options:"
     flows_usage
     echo "  packets    Capture packets information in pcap format."
     echo "        Options:"
     packets_usage
+    echo "  follow     Follow collector logs when running in background."
+    echo "  stop       Stop collection by removing agent daemonset."
+    echo "  copy       Copy generated files locally."
     echo "  cleanup    Remove netobserv components."
     echo "  version    Print software version."
     echo
@@ -90,6 +95,18 @@ case "$1" in
     flows $* ;;
 "packets")
     packets $* ;;
+"follow")
+    # run follow command
+    follow
+    exit 0 ;;
+"stop")
+    # run deleteDaemonset command
+    deleteDaemonset
+    exit 0 ;;
+"copy")
+    # run copy output command
+    copyOutput
+    exit 0 ;;
 "cleanup")
     # run cleanup command
     cleanup
@@ -101,7 +118,14 @@ esac
 
 trap cleanup EXIT
 
-setup $command $filter
+setup $command $options
+
+runCommand="sleep infinity"
+execCommand="/network-observability-cli get-$command ${options:+"--options" "${options//--/}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes"
+if [[ "$runBackground" == "true" ]]; then
+  runCommand="$execCommand & $runCommand"
+  execCommand=""
+fi
 
 echo "Running network-observability-cli get-$command... "
 ${K8S_CLI_BIN} run \
@@ -109,8 +133,9 @@ ${K8S_CLI_BIN} run \
   collector \
   --image=$img\
   --image-pull-policy='Always' \
+  --overrides='{ "spec": { "serviceAccount": "netobserv-cli" }  }' \
   --restart='Never' \
-  --command -- sleep infinity
+  --command -- $runCommand
 
 ${K8S_CLI_BIN} wait \
   -n netobserv-cli \
@@ -118,7 +143,11 @@ ${K8S_CLI_BIN} wait \
 
 captureStarted=true
 
-${K8S_CLI_BIN} exec -i --tty \
-  -n netobserv-cli \
-  collector \
-  -- /network-observability-cli get-$command ${filter:+"--filter" "${filter//--/}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes
+if [ -n "${execCommand}" ]; then
+  ${K8S_CLI_BIN} exec -i --tty \
+    -n netobserv-cli \
+    collector \
+    -- $execCommand
+else 
+  echo "Background capture started. Use 'oc netobserv follow' to see it's progress."
+fi

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -154,5 +154,8 @@ if [ -n "${execCommand}" ]; then
     collector \
     -- $execCommand
 else 
-  echo "Background capture started. Use 'oc netobserv follow' to see its progress."
+  echo "Background capture started. Use:"
+  echo " - '${K8S_CLI_BIN} netobserv follow' to see the capture progress"
+  echo " - '${K8S_CLI_BIN} netobserv copy' to copy the generated files locally"
+  echo " - '${K8S_CLI_BIN} netobserv cleanup' to remove the netobserv components"
 fi

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -120,8 +120,13 @@ trap cleanup EXIT
 
 setup $command $options
 
+# convert options to string
+optionStr="${options//--/}"
+optionStr="${optionStr// /|}"
+
+# prepare commands & args
 runCommand="sleep infinity"
-execCommand="/network-observability-cli get-$command ${options:+"--options" "${options//--/}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes"
+execCommand="/network-observability-cli get-$command ${optionStr:+"--options" "${optionStr}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes"
 if [[ "$runBackground" == "true" ]]; then
   runCommand="$execCommand & $runCommand"
   execCommand=""

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -154,5 +154,5 @@ if [ -n "${execCommand}" ]; then
     collector \
     -- $execCommand
 else 
-  echo "Background capture started. Use 'oc netobserv follow' to see it's progress."
+  echo "Background capture started. Use 'oc netobserv follow' to see its progress."
 fi

--- a/e2e/script_test.go
+++ b/e2e/script_test.go
@@ -30,7 +30,7 @@ func TestHelpCommand(t *testing.T) {
 		assert.Contains(t, str, "Find more information at: https://github.com/netobserv/network-observability-cli/")
 		// ensure help to display proper options
 		assert.Contains(t, str, "Syntax: netobserv [flows|packets|cleanup] [options]")
-		assert.Contains(t, str, "flows      Capture flows information. You can specify an optional interface name as filter such as 'netobserv flows br-ex'.")
+		assert.Contains(t, str, "flows      Capture flows information in JSON format.")
 		assert.Contains(t, str, "packets    Capture packets information in pcap format.")
 		assert.Contains(t, str, "cleanup    Remove netobserv components.")
 		assert.Contains(t, str, "version    Print software version.")

--- a/res/service-account.yml
+++ b/res/service-account.yml
@@ -10,6 +10,7 @@ metadata:
   name: netobserv-cli
   namespace: netobserv-cli
 rules:
+# allow running in privileged
   - apiGroups:
      - security.openshift.io
     resourceNames:
@@ -18,36 +19,35 @@ rules:
      - securitycontextconstraints
     verbs:
      - use
-  - verbs:
+# allow agents deletion from collector
+  - apiGroups:
+     - apps
+    resources:
+     - daemonsets
+    verbs:
      - list
      - get
      - watch
-    apiGroups:
+     - delete
+# allow pipeline enrichment
+  - apiGroups:
      - ''
     resources:
      - pods
      - services
      - nodes
-  - verbs:
+    verbs:
      - list
      - get
      - watch
-    apiGroups:
+  - apiGroups:
      - apps
     resources:
      - replicasets
-  - verbs:
-     - create
-     - delete
-     - patch
-     - update
+    verbs:
+     - list
      - get
      - watch
-     - list
-    apiGroups:
-     - autoscaling
-    resources:
-     - horizontalpodautoscalers
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

Add new options / commands to run in background:
- `--background=true` to run either flow or packet capture without the need to connect the collector pod
- `follow` command to connect an existing collector and see its output
- `stop` to remove agents without removing the collector pod
- `copy` to copy the output of a running / ended collection

When the collection limits are reached (max time or bytes), the collector pod destroy the agents using netobserv CLI itself: `oc netobserv stop`.
The collector pod keep running to let the user copy the output before cleaning the capture.
The cleanup mechanism has been improved by cleaning both daemonset and pod before cleaning up the namespace.

## How to use / test

Run a short flow capture:
```
$ ./build/oc-netobserv flows --background=true --max-time=30s
```

Connect the pod to see the live output:
```
$ ./build/oc-netobserv follow
```
You will see the flow table and the time / bytes increasing as usual. However, you can't interract with the UI.
When the limit is reached, the UI suggest you to copy the output and clean. The agents are destroyed at this point.

Copy the output using:
```
$ ./build/oc-netobserv copy
```

Cleanup the capture:
```
$ ./build/oc-netobserv cleanup
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [X] Does this PR require product documentation?
  * [x] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
