### PR TITLE
NETOBSERV-1908 Be able to customize namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,6 @@ FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi:9.4
 WORKDIR /
 
 COPY --from=builder /opt/app-root/build .
-COPY --from=builder /opt/app-root/build .
 COPY --from=builder /tmp/oc /usr/bin/oc
 COPY --from=builder /tmp/kubectl /usr/bin/kubectl
 COPY --from=builder --chown=65532:65532 /opt/app-root/output /output

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -15,6 +15,14 @@ if [ -z "${runBackground+x}" ]; then runBackground="false"; fi
 # options such as filters, background etc
 options=""
 
+# namespace for this run
+namespace="netobserv-cli"
+
+if [ -n "$NETOBSERV_NAMESPACE" ]; then
+  echo "using custom namespace $NETOBSERV_NAMESPACE"
+  namespace="$NETOBSERV_NAMESPACE"
+fi
+
 # CLI image to use
 img="quay.io/netobserv/network-observability-cli:main"
 
@@ -134,7 +142,7 @@ fi
 
 echo "Running network-observability-cli get-$command... "
 ${K8S_CLI_BIN} run \
-  -n netobserv-cli \
+  -n $namespace \
   collector \
   --image=$img\
   --image-pull-policy='Always' \
@@ -143,14 +151,14 @@ ${K8S_CLI_BIN} run \
   --command -- $runCommand
 
 ${K8S_CLI_BIN} wait \
-  -n netobserv-cli \
+  -n $namespace \
   --for=condition=Ready pod/collector || exit 1
 
 captureStarted=true
 
 if [ -n "${execCommand}" ]; then
   ${K8S_CLI_BIN} exec -i --tty \
-    -n netobserv-cli \
+    -n $namespace \
     collector \
     -- $execCommand
 else 

--- a/res/collector-service.yml
+++ b/res/collector-service.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: collector
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
 spec:
   selector:
     run: collector

--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: netobserv-cli
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
   labels:
     app: netobserv-cli
 spec:
@@ -131,7 +131,7 @@ spec:
                       "write":{
                           "type":"grpc",
                           "grpc":{
-                            "targetHost":"collector.netobserv-cli.svc.cluster.local",
+                            "targetHost":"{{TARGET_HOST}}",
                             "targetPort":9999
                           }
                       }

--- a/res/namespace.yml
+++ b/res/namespace.yml
@@ -1,7 +1,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: netobserv-cli
+  name: "{{NAME}}"
   labels:
     app: netobserv
     pod-security.kubernetes.io/enforce: privileged

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: netobserv-cli
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
   labels:
     app: netobserv-cli
 spec:
@@ -115,7 +115,7 @@ spec:
                       "write":{
                           "type":"grpc",
                           "grpc":{
-                            "targetHost":"collector.netobserv-cli.svc.cluster.local",
+                            "targetHost":"{{TARGET_HOST}}",
                             "targetPort":9999
                           }
                       }

--- a/res/service-account.yml
+++ b/res/service-account.yml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: netobserv-cli
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: netobserv-cli
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
 rules:
 # allow running in privileged
   - apiGroups:
@@ -53,11 +53,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: netobserv-cli
-  namespace: netobserv-cli
+  namespace: "{{NAMESPACE}}"
 subjects:
   - kind: ServiceAccount
     name: netobserv-cli
-    namespace: netobserv-cli
+    namespace: "{{NAMESPACE}}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Description

Allow custom namespace using `NETOBSERV_NAMESPACE` env variable.

Example:
```
$ NETOBSERV_NAMESPACE=test ./build/oc-netobserv flows
```

## Dependencies

Based on https://github.com/netobserv/network-observability-cli/pull/102

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
