### PR TITLE
Align build steps - distinguish clean vs dev builds

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -35,10 +35,10 @@ jobs:
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
         run: |
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} CLEAN_BUILD=1 make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} CLEAN_BUILD=1 OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
           if [[ "main" == "$WF_VERSION" ]]; then
-            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
+            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest CLEAN_BUILD=1 make images
           fi
 
   codecov:

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} CLEAN_BUILD=1 make images
       - name: make commands
         run: USER=netobserv VERSION=${{ env.short_sha }} make commands
       - name: upload commands

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: build and push manifest with images
-        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
       - name: build plugin artifact
         run: IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make release
       - name: create github release

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,13 @@ COPY cmd cmd
 COPY main.go main.go
 COPY go.mod go.mod
 COPY go.sum go.sum
-COPY commands/ commands/
 COPY vendor/ vendor/
 
 # Build collector
 RUN GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -a -o build/network-observability-cli
 
 # We still need Makefile & resources for oc-commands; copy them after go build for caching
+COPY commands/ commands/
 COPY res/ res/
 COPY scripts/ scripts/
 COPY Makefile Makefile

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -1,7 +1,0 @@
-FROM docker.io/library/golang:1.22 as builder
-COPY . .
-
-RUN make compile
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
-
-COPY --from=builder /go/build/ /releases

--- a/main.go
+++ b/main.go
@@ -10,14 +10,14 @@ import (
 )
 
 var (
-	BuildVersion string
-	BuildDate    string
+	buildVersion = "unknown"
+	buildDate    = "unknown"
 )
 
 func main() {
 	// Initial log message
-	fmt.Printf("Starting %s:\n=====\nBuild Version: %s\nBuild Date: %s\n\n",
-		filepath.Base(os.Args[0]), BuildVersion, BuildDate)
+	fmt.Printf("Starting %s:\n=====\nBuild version: %s\nBuild date: %s\n\n",
+		filepath.Base(os.Args[0]), buildVersion, buildDate)
 
 	err := cmd.Execute()
 	if err != nil {


### PR DESCRIPTION
- Reducing the Dockerfile dependencies allows faster dev builds
- Optimize docker caching wrt oc-commands dependencies
- Align also with other repos wrt build date / version (it was not correctly implemented, with variable names mismatch)
- Remove duplicated "make build" definitions
