### PR TITLE
NETOBSERV-2005: Allow populaiting only single filter rules for cli usecase

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -45,42 +45,15 @@ spec:
             value: "false"
           - name: ENABLE_FLOW_FILTER
             value: "false"
-          - name: FILTER_DIRECTION
-            value: ""
-          - name: FILTER_IP_CIDR
-            value: "0.0.0.0/0"
-          - name: FILTER_PROTOCOL
-            value: ""
-          - name: FILTER_SOURCE_PORT
-            value: ""
-          - name: FILTER_DESTINATION_PORT
-            value: ""
-          - name: FILTER_PORT
-            value: ""
-          - name:  FILTER_SOURCE_PORT_RANGE
-            value: ""
-          - name: FILTER_DESTINATION_PORT_RANGE
-            value: ""
-          - name: FILTER_PORT_RANGE
-            value: ""
-          - name:  FILTER_SOURCE_PORTS
-            value: ""
-          - name: FILTER_DESTINATION_PORTS
-            value: ""
-          - name: FILTER_PORTS
-            value: ""
-          - name: FILTER_ICMP_TYPE
-            value: ""
-          - name: FILTER_ICMP_CODE
-            value: ""
-          - name: FILTER_PEER_IP
-            value: ""
-          - name: FILTER_TCP_FLAGS
-            value: ""
-          - name: FILTER_DROPS
-            value: "false"
-          - name: FILTER_ACTION
-            value: "Accept"
+          - name: FLOW_FILTER_RULES
+            value: >
+              [ { "direction": "", "ip_cidr": "0.0.0.0/0", "protocol": "", "source_port": 0,
+                "destination_port": 0, "port": 0, "source_port_range": "",
+                "source_ports": "", "destination_port_range": "",
+                "destination_ports": "", "port_range": "", "ports": "",
+                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "action": "Accept",
+                "tcp_flags": "", "drops": false } 
+              ]
           - name: EXPORT
             value: "direct-flp"
           - name: FLP_CONFIG

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -31,40 +31,15 @@ spec:
             value: "false"
           - name: LOG_LEVEL
             value: info
-          - name: FILTER_DIRECTION
-            value: ""
-          - name: FILTER_IP_CIDR
-            value: "0.0.0.0/0"
-          - name: FILTER_PROTOCOL
-            value: ""
-          - name: FILTER_SOURCE_PORT
-            value: ""
-          - name: FILTER_DESTINATION_PORT
-            value: ""
-          - name: FILTER_PORT
-            value: ""
-          - name:  FILTER_SOURCE_PORT_RANGE
-            value: ""
-          - name: FILTER_DESTINATION_PORT_RANGE
-            value: ""
-          - name: FILTER_PORT_RANGE
-            value: ""
-          - name:  FILTER_SOURCE_PORTS
-            value: ""
-          - name: FILTER_DESTINATION_PORTS
-            value: ""
-          - name: FILTER_PORTS
-            value: ""
-          - name: FILTER_ICMP_TYPE
-            value: ""
-          - name: FILTER_ICMP_CODE
-            value: ""
-          - name: FILTER_PEER_IP
-            value: ""
-          - name: FILTER_DROPS
-            value: "false"
-          - name: FILTER_ACTION
-            value: "Accept"
+          - name: FLOW_FILTER_RULES
+            value: >
+              [ { "direction": "", "ip_cidr": "0.0.0.0/0", "protocol": "", "source_port": 0,
+                "destination_port": 0, "port": 0, "source_port_range": "",
+                "source_ports": "", "destination_port_range": "",
+                "destination_ports": "", "port_range": "", "ports": "",
+                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "action": "Accept",
+                "tcp_flags": "", "drops": false } 
+              ]
           - name: EXPORT
             value: "direct-flp"
           - name: FLP_CONFIG

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -397,58 +397,58 @@ function edit_manifest() {
     yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_FLOW_FILTER\").value|=\"$2\"" "$3"
     ;;
   "filter_direction")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DIRECTION\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.direction = \"$2\")| tostring)" "$3"
     ;;
   "filter_cidr")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_IP_CIDR\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.ip_cidr = \"$2\")| tostring)" "$3"
     ;;
   "filter_protocol")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PROTOCOL\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.protocol = \"$2\")| tostring)" "$3"
     ;;
   "filter_sport")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_SOURCE_PORT\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.source_port = $2)| tostring)" "$3"
     ;;
   "filter_dport")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DESTINATION_PORT\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.destination_port = $2)| tostring)" "$3"
     ;;
   "filter_port")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PORT\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.port = $2)| tostring)" "$3"
     ;;
   "filter_sport_range")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_SOURCE_PORT_RANGE\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.source_port_range = \"$2\")| tostring)" "$3"
     ;;
   "filter_dport_range")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DESTINATION_PORT_RANGE\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.destination_port_range = \"$2\")| tostring)" "$3"
     ;;
   "filter_port_range")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PORT_RANGE\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.port_range = \"$2\")| tostring)" "$3"
     ;;
   "filter_sports")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_SOURCE_PORTS\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.source_ports = \"$2\")| tostring)" "$3"
     ;;
-  "filter_dportS")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DESTINATION_PORTS\").value|=\"$2\"" "$3"
+  "filter_dports")
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.destination_ports = \"$2\")| tostring)" "$3"
     ;;
   "filter_ports")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PORTS\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.ports = \"$2\")| tostring)" "$3"
     ;;
   "filter_icmp_type")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_ICMP_TYPE\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.icmp_type = $2)| tostring)" "$3"
     ;;
   "filter_icmp_code")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_ICMP_CODE\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.icmp_code = $2)| tostring)" "$3"
     ;;
   "filter_peer_ip")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_PEER_IP\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.peer_ip = \"$2\")| tostring)" "$3"
     ;;
   "filter_action")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_ACTION\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.action = \"$2\")| tostring)" "$3"
     ;;
   "filter_tcp_flags")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_TCP_FLAGS\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.tcp_flags = \"$2\")| tostring)" "$3"
     ;;
   "filter_pkt_drops")
-    yq e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"FILTER_DROPS\").value|=\"$2\"" "$3"
+    yq e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.drops = $2)| tostring)" "$3"
     ;;
   "filter_regexes")
     copyFLPConfig "$3"


### PR DESCRIPTION
## Description

ebpf agent will support multi flow filter rules however we will limit cli to only single rule
till we find a more efficient way to pass in more rules
## Dependencies

https://github.com/netobserv/netobserv-ebpf-agent/pull/473

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
