### PR TITLE
Nit: better text asking for copying

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -251,7 +251,7 @@ function cleanup {
       copyOutput
     elif [ "$copy" = "prompt" ]; then
       while true; do
-        read -rp "Copy the capture output locally ?" yn
+        read -rp "Copy the capture output locally? [yes/no] " yn
         case $yn in
         [Yy]*)
           copyOutput


### PR DESCRIPTION
It's conventional and more user-friendly to tell which answers are accepted (even if more than that would actually work), so user isn't worried about typing wrong things

Also, no space before question mark in English
