### PR TITLE
Upgrade linter + refactor display loops

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters:
     - cyclop
     - errname
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - gocritic
     - gofmt
     - gosimple
@@ -16,15 +16,17 @@ linters:
     - stylecheck
     - typecheck
     - unused
+run:
+  go: "1.22"
 linters-settings:
-  stylecheck:
-    go: "1.22"
   gocritic:
     enabled-checks:
       - hugeParam
       - rangeExprCopy
       - rangeValCopy
       - indexAlloc
-      - deprecatedComment
+    settings:
+      ifElseChain:
+        minThreshold: 3
   cyclop:
     max-complexity: 150 # TODO: reduce that to 20

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifneq ($(CLEAN_BUILD),)
 	LDFLAGS ?= -X 'main.buildVersion=${VERSION}-${BUILD_SHA}' -X 'main.buildDate=${BUILD_DATE}'
 endif
 
-GOLANGCI_LINT_VERSION = v1.54.2
+GOLANGCI_LINT_VERSION = v1.61.0
 YQ_VERSION = v4.43.1
 
 # build a single arch target provided as argument

--- a/cmd/display_loop.go
+++ b/cmd/display_loop.go
@@ -1,0 +1,56 @@
+package cmd
+
+import "slices"
+
+type displayLoop struct {
+	all     []displayLoopItem
+	current int
+}
+
+type displayLoopItem struct {
+	name    string
+	columns []string
+	group   []string
+}
+
+func (dl *displayLoop) prev() {
+	dl.current += len(dl.all) - 1
+	dl.current %= len(dl.all)
+}
+
+func (dl *displayLoop) next() {
+	dl.current++
+	dl.current %= len(dl.all)
+}
+
+func (dl *displayLoop) getCurrentItems() []displayLoopItem {
+	current := dl.all[dl.current]
+	if current.group == nil {
+		return []displayLoopItem{current}
+	}
+	var items []displayLoopItem
+	for _, item := range dl.all {
+		if slices.Contains(current.group, item.name) {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func (dl *displayLoop) getNames() []string {
+	var names []string
+	items := dl.getCurrentItems()
+	for _, item := range items {
+		names = append(names, item.name)
+	}
+	return names
+}
+
+func (dl *displayLoop) getCols() []string {
+	var cols []string
+	items := dl.getCurrentItems()
+	for _, item := range items {
+		cols = append(cols, item.columns...)
+	}
+	return cols
+}

--- a/cmd/display_loop_test.go
+++ b/cmd/display_loop_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestDisplayLoop(t *testing.T) {
+	enrichment.current = 0
 	assert.Equal(t, []string{"None"}, enrichment.getNames())
 	assert.Equal(t, []string{"SrcAddr", "SrcPort", "DstAddr", "DstPort"}, enrichment.getCols())
 

--- a/cmd/display_loop_test.go
+++ b/cmd/display_loop_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisplayLoop(t *testing.T) {
+	assert.Equal(t, []string{"None"}, enrichment.getNames())
+	assert.Equal(t, []string{"SrcAddr", "SrcPort", "DstAddr", "DstPort"}, enrichment.getCols())
+
+	enrichment.prev()
+	assert.Equal(t, []string{"Zone", "Host", "Owner", "Resource"}, enrichment.getNames())
+	assert.Equal(t, []string{
+		"SrcZone",
+		"DstZone",
+		"SrcHostName",
+		"SrcHostName",
+		"SrcOwnerName",
+		"SrcOwnerType",
+		"DstOwnerName",
+		"DstOwnerType",
+		"SrcName",
+		"SrcType",
+		"DstName",
+		"DstType",
+	}, enrichment.getCols())
+
+	enrichment.next()
+	assert.Equal(t, []string{"None"}, enrichment.getNames())
+	assert.Equal(t, []string{"SrcAddr", "SrcPort", "DstAddr", "DstPort"}, enrichment.getCols())
+
+	enrichment.next()
+	assert.Equal(t, []string{"Zone"}, enrichment.getNames())
+	assert.Equal(t, []string{"SrcZone", "DstZone"}, enrichment.getCols())
+}

--- a/cmd/flow_capture.go
+++ b/cmd/flow_capture.go
@@ -35,7 +35,7 @@ var (
 	lastFlows   = []config.GenericMap{}
 
 	features = displayLoop{
-		current: 6,
+		current: featureDefaultIndex,
 		all: []displayLoopItem{
 			{name: "Raw"},
 			{name: "Standard", columns: []string{"Dir", "Interfaces", "Proto", "Dscp", "Bytes", "Packets"}},
@@ -48,7 +48,7 @@ var (
 	}
 
 	enrichment = displayLoop{
-		current: 4,
+		current: enrichmentDefaultIndex,
 		all: []displayLoopItem{
 			{name: "None", columns: []string{"SrcAddr", "SrcPort", "DstAddr", "DstPort"}},
 			{name: "Zone", columns: []string{"SrcZone", "DstZone"}},
@@ -58,6 +58,11 @@ var (
 			{group: []string{"Zone", "Host", "Owner", "Resource"}},
 		},
 	}
+)
+
+const (
+	featureDefaultIndex    = 6 // All feats.
+	enrichmentDefaultIndex = 4 // Resources
 )
 
 func runFlowCapture(_ *cobra.Command, _ []string) {

--- a/cmd/flow_capture_test.go
+++ b/cmd/flow_capture_test.go
@@ -68,8 +68,8 @@ func TestFlowTableMultipleFlows(t *testing.T) {
 		buf.Reset()
 
 		// update time and bytes for next flow
-		flowTime = flowTime + 1000
-		bytes = bytes + 1000
+		flowTime += 1000
+		bytes += 1000
 
 		// add flow to table
 		parseGenericMapAndDisplay([]byte(fmt.Sprintf(`{

--- a/cmd/flow_capture_test.go
+++ b/cmd/flow_capture_test.go
@@ -54,6 +54,7 @@ func TestFlowTableMultipleFlows(t *testing.T) {
 
 	// set display to standard without enrichment
 	features.current = 1
+	enrichment.current = 0
 
 	// set time and bytes per flow
 	flowTime := 1704063600000

--- a/cmd/flow_db.go
+++ b/cmd/flow_db.go
@@ -96,16 +96,17 @@ func insertFlowToDB(db *sql.DB, buf []byte) error {
 	}
 	// Insert message into database
 	var flowSQL string
-	if flow["PktDropPackets"] != 0 && flow["DnsId"] != 0 {
+	switch {
+	case flow["PktDropPackets"] != 0 && flow["DnsId"] != 0:
 		flowSQL =
 			`INSERT INTO flow(DnsErrno, Dscp, DstAddr, DstPort, Interface, Proto, SrcAddr, SrcPort, Bytes, Packets, PktDropLatestDropCause, PktDropBytes, PktDropPackets, DnsId, DnsFlagsResponseCode, DnsLatencyMs, TimeFlowRttNs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	} else if flow["PktDropPackets"] != 0 {
+	case flow["PktDropPackets"] != 0:
 		flowSQL =
 			`INSERT INTO flow(DnsErrno, Dscp, DstAddr, DstPort, Interface, Proto, SrcAddr, SrcPort, Bytes, Packets, PktDropLatestDropCause, PktDropBytes, PktDropPackets, TimeFlowRttNs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	} else if flow["DnsId"] != 0 {
+	case flow["DnsId"] != 0:
 		flowSQL =
 			`INSERT INTO flow(DnsErrno, Dscp, DstAddr, DstPort, Interface, Proto, SrcAddr, SrcPort, Bytes, Packets, DnsId, DnsFlagsResponseCode, DnsLatencyMs, TimeFlowRttNs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-	} else {
+	default:
 		flowSQL =
 			`INSERT INTO flow(DnsErrno, Dscp, DstAddr, DstPort, Interface, Proto, SrcAddr, SrcPort, Bytes, Packets, TimeFlowRttNs) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	}
@@ -116,26 +117,27 @@ func insertFlowToDB(db *sql.DB, buf []byte) error {
 		return fmt.Errorf("error preparing SQL: %v", err.Error())
 	}
 
-	if flow["PktDropLatestDropCause"] != 0 && flow["DnsId"] != 0 {
+	switch {
+	case flow["PktDropLatestDropCause"] != 0 && flow["DnsId"] != 0:
 		_, err = statement.Exec(
 			flow["DNSErrno"], flow["Dscp"], flow["DstAddr"], flow["DstPort"], flow["Interface"],
 			flow["Proto"], flow["SrcAddr"], flow["SrcPort"], flow["Bytes"], flow["Packets"],
 			flow["PktDropLatestDropCause"], flow["PktDropBytes"], flow["PktDropPackets"],
 			flow["DnsId"], flow["DnsFlagsResponseCode"], flow["DnsLatencyMs"],
 			flow["TimeFlowRttNs"])
-	} else if flow["PktDropLatestDropCause"] != 0 {
+	case flow["PktDropLatestDropCause"] != 0:
 		_, err = statement.Exec(
 			flow["DNSErrno"], flow["Dscp"], flow["DstAddr"], flow["DstPort"], flow["Interface"],
 			flow["Proto"], flow["SrcAddr"], flow["SrcPort"], flow["Bytes"], flow["Packets"],
 			flow["PktDropLatestDropCause"], flow["PktDropBytes"], flow["PktDropPackets"],
 			flow["TimeFlowRttNs"])
-	} else if flow["DnsId"] != 0 {
+	case flow["DnsId"] != 0:
 		_, err = statement.Exec(
 			flow["DNSErrno"], flow["Dscp"], flow["DstAddr"], flow["DstPort"], flow["Interface"],
 			flow["Proto"], flow["SrcAddr"], flow["SrcPort"], flow["Bytes"], flow["Packets"],
 			flow["DnsId"], flow["DnsFlagsResponseCode"], flow["DnsLatencyMs"],
 			flow["TimeFlowRttNs"])
-	} else {
+	default:
 		_, err = statement.Exec(
 			flow["DNSErrno"], flow["Dscp"], flow["DstAddr"], flow["DstPort"], flow["Interface"],
 			flow["Proto"], flow["SrcAddr"], flow["SrcPort"], flow["Bytes"], flow["Packets"],

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,9 +28,7 @@ var (
 	maxTime  time.Duration
 	maxBytes int64
 
-	currentTime = func() time.Time {
-		return time.Now()
-	}
+	currentTime  = time.Now
 	startupTime  = currentTime()
 	lastRefresh  = startupTime
 	totalBytes   = int64(0)
@@ -49,7 +47,7 @@ var (
 		Use:   "network-observability-cli",
 		Short: "network-observability-cli is an interactive Flow and Packet visualizer",
 		Long:  `An interactive Flow / PCAP collector and visualization tool`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,6 +83,8 @@ func setup() {
 	// clear filters and previous flows
 	regexes = []string{}
 	lastFlows = []config.GenericMap{}
+	features.current = featureDefaultIndex
+	enrichment.current = enrichmentDefaultIndex
 }
 
 func resetTime() {

--- a/e2e/cluster/kind.go
+++ b/e2e/cluster/kind.go
@@ -85,14 +85,14 @@ func (k *Kind) GetLogsDir() string {
 
 // export logs into the e2e-logs folder of the base directory.
 func (k *Kind) exportLogs() env.Func {
-	return func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+	return func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 		logsDir := k.GetLogsDir()
 		klog.WithField("directory", logsDir).Info("exporting cluster logs")
 		exe := gexe.New()
 		out := exe.Run("kind export logs " + logsDir + " --name " + k.clusterName)
 		klog.WithField("out", out).Info("exported cluster logs")
 
-		//move output files to cluster logs folder
+		// move output files to cluster logs folder
 		err := os.Rename(path.Join(k.baseDir, "e2e", "tmp"), path.Join(logsDir, "output"))
 		if err != nil {
 			klog.Error(err)
@@ -112,7 +112,7 @@ func (k *Kind) GetAgentLogs() string {
 
 // delete netobserv-cli namespace
 func (k *Kind) deleteNamespace() env.Func {
-	return func(ctx context.Context, config *envconf.Config) (context.Context, error) {
+	return func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 		exe := gexe.New()
 		out := exe.Run("kubectl delete namespace netobserv-cli")
 		klog.WithField("out", out).Info("deleted namespace")


### PR DESCRIPTION
Upgrading linter showed some potential actual bugs during cleanup / exit, where deferred functions aren't called when something like `log.Fatal` or `os.Exit` is called, so I had to move things around to fix that (basically: having functions returning errors in case of doing something Fatal, and dealing with fatality in caller)