### PR TITLE
NETOBSERV-2016 refactor display options

### DIFF
--- a/cmd/map_format.go
+++ b/cmd/map_format.go
@@ -431,18 +431,6 @@ func toTimeString(genericMap config.GenericMap, fieldName string) string {
 	return emptyText
 }
 
-func toTitles(strs []string) []string {
-	titleCaseStrs := []string{}
-	for _, s := range strs {
-		titleCaseStrs = append(titleCaseStrs, fmt.Sprintf("%s%s", strings.ToUpper(s[:1]), s[1:]))
-	}
-	return titleCaseStrs
-}
-
-func toShortTitleStr(strs []string) string {
-	return replacer.Replace(strings.Join(toTitles(strs), ","))
-}
-
 func ToTableColName(id string) string {
 	name := id
 	colIndex := slices.IndexFunc(cfg.Columns, func(c *ColumnConfig) bool { return c.ID == id })

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -1,0 +1,82 @@
+package cmd
+
+type option struct {
+	all     []optionItem
+	current int
+}
+
+type optionItem struct {
+	name string
+	ids  []string
+}
+
+var (
+	allOptions = "All"
+	noOptions  = "None"
+
+	// displays
+	rawDisplay           = "Raw"
+	standardDisplay      = "Standard"
+	pktDropFeature       = "pktDrop"
+	dnsFeature           = "dnsTracking"
+	rttFeature           = "flowRTT"
+	networkEventsDisplay = "networkEvents"
+	display              = option{
+		all: []optionItem{
+			// exclusive displays
+			{name: rawDisplay},
+			{name: standardDisplay},
+			// per feature displays
+			{name: "Packet drops", ids: []string{pktDropFeature}},
+			{name: "DNS", ids: []string{dnsFeature}},
+			{name: "RTT", ids: []string{rttFeature}},
+			{name: "Network events", ids: []string{networkEventsDisplay}},
+			// all features display
+			{name: allOptions, ids: []string{pktDropFeature, dnsFeature, rttFeature, networkEventsDisplay}},
+		},
+		// standard display by default
+		current: 1,
+	}
+
+	// enrichments
+	enrichment = option{
+		all: []optionItem{
+			// no enrichment
+			{name: noOptions},
+			// per field enrichments
+			{name: "Cluster", ids: []string{"ClusterName"}},
+			{name: "Zone", ids: []string{"SrcZone", "DstZone"}},
+			{name: "Host", ids: []string{"SrcK8S_HostIP", "DstK8S_HostIP", "SrcK8S_HostName", "DstK8S_HostName", "FlowDirection"}},
+			{name: "Namespace", ids: []string{"SrcK8S_Namespace", "DstK8S_Namespace"}},
+			{name: "Owner", ids: []string{"SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_OwnerName", "DstK8S_OwnerName", "SrcK8S_Namespace", "DstK8S_Namespace"}},
+			{name: "Resource", ids: []string{"SrcK8S_Type", "DstK8S_Type", "SrcK8S_Name", "DstK8S_Name", "SrcK8S_Namespace", "DstK8S_Namespace"}},
+			{name: "SubnetLabel", ids: []string{"SrcSubnetLabel", "DstSubnetLabel"}},
+			// all fields
+			{name: allOptions, ids: []string{
+				"ClusterName",
+				"SrcZone", "DstZone",
+				"SrcK8S_HostIP", "DstK8S_HostIP", "SrcK8S_HostName", "DstK8S_HostName",
+				"SrcK8S_Namespace", "DstK8S_Namespace",
+				"SrcK8S_OwnerType", "DstK8S_OwnerType", "SrcK8S_OwnerName", "DstK8S_OwnerName",
+				"SrcK8S_Type", "DstK8S_Type", "SrcK8S_Name", "DstK8S_Name",
+				"SrcSubnetLabel", "DstSubnetLabel",
+			}},
+		},
+		// resource enrichment by default
+		current: 6,
+	}
+)
+
+func (opt *option) getCurrentItem() optionItem {
+	return opt.all[opt.current]
+}
+
+func (opt *option) prev() {
+	opt.current += len(opt.all) - 1
+	opt.current %= len(opt.all)
+}
+
+func (opt *option) next() {
+	opt.current++
+	opt.current %= len(opt.all)
+}


### PR DESCRIPTION
## Description

Refactor display options to improve code quality. Also took the chance to add namespace enrichment view

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
