### PR TITLE
NETOBSERV-2047: Add peerCIDR flow filtering support

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -51,7 +51,7 @@ spec:
                 "destination_port": 0, "port": 0, "source_port_range": "",
                 "source_ports": "", "destination_port_range": "",
                 "destination_ports": "", "port_range": "", "ports": "",
-                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "action": "Accept",
+                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "peer_cidr": "", action": "Accept",
                 "tcp_flags": "", "drops": false } 
               ]
           - name: EXPORT

--- a/res/packet-capture.yml
+++ b/res/packet-capture.yml
@@ -37,7 +37,7 @@ spec:
                 "destination_port": 0, "port": 0, "source_port_range": "",
                 "source_ports": "", "destination_port_range": "",
                 "destination_ports": "", "port_range": "", "ports": "",
-                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "action": "Accept",
+                "icmp_type": 0, "icmp_code": 0, "peer_ip": "", "peer_cidr": "", "action": "Accept",
                 "tcp_flags": "", "drops": false } 
               ]
           - name: EXPORT

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -360,6 +360,7 @@ function filters_usage {
   echo "          --icmp_type:              filter ICMP type                           (default: n/a)"
   echo "          --icmp_code:              filter ICMP code                           (default: n/a)"
   echo "          --peer_ip:                filter peer IP                             (default: n/a)"
+  echo "          --peer_cidr:              filter peer CIDR                           (default: n/a)"
   echo "          --drops:                  filter flows with only dropped packets     (default: false)"
   echo "          --regexes:                filter flows using regex                   (default: n/a)"
 }
@@ -503,6 +504,9 @@ function edit_manifest() {
     ;;
   "filter_peer_ip")
     "$YQ_BIN" e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.peer_ip = \"$2\")| tostring)" "$3"
+    ;;
+  "filter_peer_cidr")
+    "$YQ_BIN" e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.peer_cidr = \"$2\")| tostring)" "$3"
     ;;
   "filter_action")
     "$YQ_BIN" e --inplace " .spec.template.spec.containers[0].env[] |= select(.name == \"FLOW_FILTER_RULES\").value |=(fromjson | map(.action = \"$2\")| tostring)" "$3"
@@ -716,6 +720,9 @@ function check_args_and_apply() {
       ;;
     --peer_ip) # Peer IP
       edit_manifest "filter_peer_ip" "$value" "$2"
+      ;;
+    --peer_cidr) # Peer CIDR
+      edit_manifest "filter_peer_cidr" "$value" "$2"
       ;;
     --action) # Filter action
       if [[ "$value" == "Accept" || "$value" == "Reject" ]]; then


### PR DESCRIPTION
## Description

Extend flow filtering to include peerCIDR as an option

## Dependencies
https://github.com/netobserv/netobserv-ebpf-agent/pull/501

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
