### PR TITLE
NETOBSERV-1578 Fix bash issues on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ ifneq ($(CLEAN_BUILD),)
 endif
 
 GOLANGCI_LINT_VERSION = v1.61.0
+BASH_VERSION = v4.2.0
 YQ_VERSION = v4.43.1
 
 # build a single arch target provided as argument
@@ -151,6 +152,7 @@ commands: ## Generate either oc or kubectl plugins and add them to build folder
 	PULL_POLICY=$(PULL_POLICY) \
 	AGENT_IMAGE=$(AGENT_IMAGE) \
 	VERSION=$(VERSION) \
+	REQUIRED_BASH_VERSION=$(BASH_VERSION) \
 	REQUIRED_YQ_VERSION=$(YQ_VERSION) \
 	SUPPORTED_ARCHS=$(MULTIARCH_TARGETS) \
 	./scripts/inject.sh

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "./scripts/functions.sh"
 source "./scripts/dependencies_check.sh"
 

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -94,7 +94,8 @@ function metrics() {
 if [[ ! "$*" =~ ^(.*)help|version(.*) ]]; then
   required_yq_version="v0.0.0"
   supported_archs=""
-  check_dependencies "$required_yq_version" "$supported_archs"
+  required_bash_version="v0.0.0"
+  check_dependencies "$required_yq_version" "$supported_archs" "$required_bash_version"
 fi
 
 case "$1" in

--- a/scripts/dependencies_check.sh
+++ b/scripts/dependencies_check.sh
@@ -30,6 +30,18 @@ function check_dependencies() {
   else
     echo "'yq' is up to date (version $current_yq_version)."
   fi
+
+  current_bash_version="v${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}.${BASH_VERSINFO[2]}"
+  required_bash_version="$3"
+  # Compare versions
+  compare_versions "${current_bash_version#v}" "${required_bash_version#v}"
+
+  if [ "$result" -eq 0 ]; then
+    echo "Please upgrade bash to $required_bash_version or up. Found version $current_bash_version."
+    exit 1
+  else
+    echo "'bash' is up to date (version $current_bash_version)."
+  fi
 }
 
 function compare_versions() {

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ADOC=./docs/netobserv_cli.adoc
 
 # Header

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -33,10 +33,17 @@ else
   sed -i.bak "s/^version=.*/version=\"$VERSION\"/" ./tmp/netobserv
 fi
 
+if [ -z "$REQUIRED_BASH_VERSION" ]; then
+  echo "require bash version is not set, keeping the current version"
+else
+  echo "updating dependencies to check for bash $REQUIRED_BASH_VERSION"
+  sed -i.bak "s/^required_bash_version=.*/required_bash_version=\"$REQUIRED_BASH_VERSION\"/" ./tmp/netobserv
+fi
+
 if [ -z "$REQUIRED_YQ_VERSION" ]; then
   echo "require yq version is not set, keeping the current version"
 else
-  echo "updating dependencies_check to check for $REQUIRED_YQ_VERSION"
+  echo "updating dependencies to check for yq $REQUIRED_YQ_VERSION"
   sed -i.bak "s/^required_yq_version=.*/required_yq_version=\"$REQUIRED_YQ_VERSION\"/" ./tmp/netobserv
 fi
 

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -x
 
 cp -a ./commands/. ./tmp

--- a/scripts/krew.sh
+++ b/scripts/krew.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SHA=$(sha256sum netobserv-cli.tar.gz | awk '{print $1}')
 

--- a/scripts/update-config.sh
+++ b/scripts/update-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Downloading frontend config from operator repo"
 curl "https://raw.githubusercontent.com/netobserv/network-observability-operator/refs/heads/main/controllers/consoleplugin/config/static-frontend-config.yaml" -o ./cmd/config.yaml


### PR DESCRIPTION
## Description

- use `#!/usr/bin/env bash` on scripts
- require bash >= 4.2.0

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
