### PR TITLE
skip ci faillure on coverage upload issues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,5 @@ jobs:
       with:
         files: ./cover.out
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
Following https://github.com/netobserv/network-observability-cli/pull/144#issuecomment-2602387025