### PR TITLE
NETOBSERV-2112: Make build FIPS compliant [1.8 backport]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN set -x; \
     curl -L -q -o /tmp/oc.tar.gz "$OC_TAR_URL" && \
     tar -C /tmp -xvf /tmp/oc.tar.gz oc kubectl
 
-# Embedd commands in case users want to pull it from collector image
+# Embed commands in case users want to pull it from collector image
 RUN USER=netobserv VERSION=main make oc-commands
 
 # Prepare output dir

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -11,8 +11,7 @@ FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.17.0-202412032103.p0.g13001b
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as builder
 
 ARG TARGETARCH
-ARG TARGETPLATFORM
-ARG VERSION="unknown"
+ARG BUILDVERSION="1.8.0"
 
 WORKDIR /opt/app-root
 
@@ -20,17 +19,20 @@ COPY cmd cmd
 COPY main.go main.go
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Build collector
+ENV GOEXPERIMENT strictfipsruntime
+RUN GOARCH=$TARGETARCH go build -tags strictfipsruntime -ldflags "-X 'main.buildVersion=${BUILDVERSION}' -X 'main.buildDate=`date +%Y-%m-%d\ %H:%M`'" -mod vendor -a -o build/network-observability-cli
+
+# We still need Makefile & resources for oc-commands; copy them after go build for caching
 COPY commands/ commands/
 COPY res/ res/
 COPY scripts/ scripts/
-COPY vendor/ vendor/
 COPY Makefile Makefile
 COPY .mk/ .mk/
 
-# Build collector
-RUN GOARCH=$TARGETARCH make compile
-
-# Embedd commands in case users want to pull it from collector image
+# Embed commands in case users want to pull it from collector image
 RUN USER=netobserv VERSION=main IMAGE="$IMAGE" AGENT_IMAGE="$AGENT_IMAGE" make oc-commands
 
 # Prepare output dir
@@ -58,5 +60,5 @@ LABEL summary="Network Observability CLI"
 LABEL maintainer="support@redhat.com"
 LABEL io.openshift.tags="network-observability-cli"
 LABEL upstream-vcs-type="git"
-LABEL upstream-vcs-ref="$COMMIT"
-LABEL version="1.8.0"
+LABEL upstream-vcs-ref=$COMMIT
+LABEL version=$BUILDVERSION


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-cli/pull/169