### PR TITLE
NETOBSERV-2107 disable dns & rtt workload metrics

### DIFF
--- a/res/metrics-pipeline-config.json
+++ b/res/metrics-pipeline-config.json
@@ -243,45 +243,6 @@
               "buckets": null
             },
             {
-              "name": "workload_rtt_seconds",
-              "type": "histogram",
-              "filters": [
-                {
-                  "key": "TimeFlowRttNs",
-                  "value": "",
-                  "type": "presence"
-                }
-              ],
-              "valueKey": "TimeFlowRttNs",
-              "labels": [
-                "SrcK8S_Namespace",
-                "DstK8S_Namespace",
-                "K8S_FlowLayer",
-                "SrcSubnetLabel",
-                "DstSubnetLabel",
-                "SrcK8S_OwnerName",
-                "DstK8S_OwnerName",
-                "SrcK8S_OwnerType",
-                "DstK8S_OwnerType",
-                "SrcK8S_Type",
-                "DstK8S_Type"
-              ],
-              "remap": null,
-              "buckets": [
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.04,
-                0.05,
-                0.075,
-                0.1,
-                0.25,
-                1
-              ],
-              "valueScale": 1000000000
-            },
-            {
               "name": "workload_drop_packets_total",
               "type": "counter",
               "filters": [
@@ -338,46 +299,6 @@
               ],
               "remap": null,
               "buckets": null
-            },
-            {
-              "name": "workload_dns_latency_seconds",
-              "type": "histogram",
-              "filters": [
-                {
-                  "key": "DnsId",
-                  "value": "",
-                  "type": "presence"
-                }
-              ],
-              "valueKey": "DnsLatencyMs",
-              "labels": [
-                "SrcK8S_Namespace",
-                "DstK8S_Namespace",
-                "K8S_FlowLayer",
-                "SrcSubnetLabel",
-                "DstSubnetLabel",
-                "SrcK8S_OwnerName",
-                "DstK8S_OwnerName",
-                "SrcK8S_OwnerType",
-                "DstK8S_OwnerType",
-                "SrcK8S_Type",
-                "DstK8S_Type",
-                "DnsFlagsResponseCode"
-              ],
-              "remap": null,
-              "buckets": [
-                0.005,
-                0.01,
-                0.02,
-                0.03,
-                0.04,
-                0.05,
-                0.075,
-                0.1,
-                0.25,
-                1
-              ],
-              "valueScale": 1000
             }
           ],
           "prefix": "on_demand_netobserv_",


### PR DESCRIPTION
## Description

Disable DNS and RTT workload metrics to avoid cardinality issues.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
