### PR TITLE
NETOBSERV-2123: remove 1.8 unsupported features from cli

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -674,32 +674,6 @@ function check_args_and_apply() {
         exit 1
       fi
       ;;
-    *enable_network_events) # Enable Network events monitoring
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
-        defaultValue "true"
-        if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "network_events_enable" "$value" "$2"
-        else
-          echo "invalid value for --enable_network_events"
-        fi
-      else
-        echo "--enable_network_events is invalid option for packets"
-        exit 1
-      fi
-      ;;
-    *enable_udn_mapping) # Enable User Defined Network mapping
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
-        defaultValue "true"
-        if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "udn_enable" "$value" "$2"
-        else
-          echo "invalid value for --enable_udn_mapping"
-        fi
-      else
-        echo "--enable_udn_mapping is invalid option for packets"
-        exit 1
-      fi
-      ;;
     *enable_pkt_translation) # Enable Packet translation
       if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
         defaultValue "true"
@@ -719,8 +693,6 @@ function check_args_and_apply() {
         edit_manifest "pkt_drop_enable" "$value" "$2"
         edit_manifest "dns_enable" "$value" "$2"
         edit_manifest "rtt_enable" "$value" "$2"
-        edit_manifest "network_events_enable" "$value" "$2"
-        edit_manifest "udn_enable" "$value" "$2"
         edit_manifest "pkt_xlat_enable" "$value" "$2"
       else
         echo "invalid value for --enable_all"

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -59,11 +59,9 @@ function version {
 function features_usage {
   echo "  --enable_all:                 enable all eBPF features                   (default: false)"
   echo "  --enable_dns:                 enable DNS tracking                        (default: false)"
-  echo "  --enable_network_events:      enable network events monitoring           (default: false)"
   echo "  --enable_pkt_translation:     enable packet translation                  (default: false)"
   echo "  --enable_pkt_drop:            enable packet drop                         (default: false)"
   echo "  --enable_rtt:                 enable RTT tracking                        (default: false)"
-  echo "  --enable_udn_mapping:         enable User Defined Network mapping (default: false)"
   echo "  --get-subnets:                get subnets information                    (default: false)"
 }
 


### PR DESCRIPTION
## Description

rm network events and udn mapping from 1.8 features list

- network events waiting for https://github.com/netobserv/network-observability-cli/pull/135 to merge
- udn mapping causing pods enrichment regression need to be investigated and fixed in 1.9 release
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
