### PR TITLE
bump ose cli image

### DIFF
--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -5,7 +5,7 @@ ARG IMAGE=registry.redhat.io/network-observability/network-observability-ebpf-ag
 ARG AGENT_IMAGE=registry.redhat.io/network-observability/network-observability-ebpf-agent-rhel9:1.8
 
 # Make kubectl & oc scripts available for copy
-FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.17.0-202412032103.p0.g13001b0.assembly.stream.el9 as ose-cli
+FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.18.0-202502040032.p0.ga50d4c0.assembly.stream.el9 as ose-cli
 
 # Build the manager binary
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as builder


### PR DESCRIPTION
Bump ose cli image to 4.18
https://catalog.redhat.com/software/containers/openshift4/ose-cli-rhel9/6528096620ebdcf82af4cbf9?architecture=amd64&image=67a16a5ebcf48c6835f943f7&container-tabs=overview