### PR TITLE
NETOBSERV-2133 CLI flows JSON

### DIFF
--- a/cmd/flow_capture.go
+++ b/cmd/flow_capture.go
@@ -79,13 +79,13 @@ func runFlowCaptureOnAddr(port int, filename string) error {
 	}
 	log.Trace("Created flow folder")
 
-	f, err = os.Create("./output/flow/" + filename + ".json")
+	f, err = os.Create("./output/flow/" + filename + ".txt")
 	if err != nil {
 		log.Errorf("Create file %s failed: %v", filename, err.Error())
 		log.Fatal(err)
 	}
 	defer f.Close()
-	log.Trace("Created json file")
+	log.Trace("Created flow logs txt file")
 
 	// Initialize sqlite DB
 	db := initFlowDB(filename)

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -297,6 +297,25 @@ function copyOutput() {
   echo "Copying collector output files..."
   mkdir -p ./output
   ${K8S_CLI_BIN} cp -n "$namespace" collector:output ./output
+  flowFile=$(find ./output -name "*txt" | sort | tail -1)
+  if [[ -n "$flowFile" ]] ; then
+    buildJSON "$flowFile"
+    rm "$flowFile"
+  fi
+}
+
+function buildJSON() {
+  file=$1
+  filename=$(basename "$file")
+  dirpath=$(dirname "$file")
+  filenamePrefix=$(echo "$filename" | sed -E 's/(.*)\..*/\1/')
+  UPDATED_JSON_FILE="$dirpath/$filenamePrefix.json"
+  { 
+    echo "["
+    # remove last line and "," (last character) of the last flowlog for valid json
+    sed '$d' "$file" | sed '$ s/.$//'
+    echo "]"
+  } >> "$UPDATED_JSON_FILE"
 }
 
 function deleteServiceMonitor() {


### PR DESCRIPTION
## Description

[NETOBSERV-2133](https://issues.redhat.com/browse/NETOBSERV-2133) CLI flows JSON 
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [X] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
