### PR TITLE
update linter to avoid memory leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifneq ($(CLEAN_BUILD),)
 	LDFLAGS ?= -X 'main.buildVersion=${VERSION}-${BUILD_SHA}' -X 'main.buildDate=${BUILD_DATE}'
 endif
 
-GOLANGCI_LINT_VERSION = v1.61.0
+GOLANGCI_LINT_VERSION = v1.64.6
 BASH_VERSION = v4.2.0
 YQ_VERSION = v4.45.1
 


### PR DESCRIPTION
I'm experiencing memory leaks using the old version of golangci-lint
Updating it fixes the issue 