### PR TITLE
NETOBSERV-2131 allow multiple regexes

### DIFF
--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -40,7 +40,8 @@ function help {
   echo "  Capture flows from a specific pod"
   echo "    netobserv flows                                           # Capture flows"
   echo "    --node-selector=kubernetes.io/hostname:my-node            # on node matching label 'kubernetes.io/hostname=my-node'"
-  echo "    --regexes=SrcK8S_Name~.*my-pod.*,DstK8S_Name~.*my-pod.*   # from or to any pod name containing 'my-pod'"
+  echo "    --regexes=SrcK8S_Name~.*my-pod.*                          # from any pod name containing 'my-pod'"
+  echo "    or --regexes=DstK8S_Name~.*my-pod.*                       # or to any pod name containing 'my-pod'"
   echo
   echo "  Capture packets on specific nodes and port"
   echo "    netobserv packets                                         # Capture packets"


### PR DESCRIPTION
## Description

Allow multiple regexes filters to manage cases such as Src OR Dst

Example:
```
oc netobserv flows --regexes="SrcK8S_Namespace~net1" or --regexes="DstK8S_Namespace~net1"
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
