### PR TITLE
gracefully fail on which check

### DIFF
--- a/scripts/dependencies_check.sh
+++ b/scripts/dependencies_check.sh
@@ -10,7 +10,7 @@ function check_dependencies() {
     YQ_BIN=$LOCAL_YQ
   else
     # Check if yq is installed
-    YQ_BIN=$(which yq 2>/dev/null)
+    YQ_BIN=$(which yq 2>/dev/null || true)
   fi
   if [ -z "$YQ_BIN" ]; then
     echo "Error: 'yq' is not installed or not in PATH."


### PR DESCRIPTION
## Description

If `yq` isnt installed, then status code returned will be 1. Krew installs plugin with `set -e` option, which means the script will silently exit at this point without further instructions on whats wrong.

In this PR we add `|| true` to get status code 0 and continue script.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
