### PR TITLE
NETOBSERV-2187: adapt regex to new query language in flp

### DIFF
--- a/commands/netobserv
+++ b/commands/netobserv
@@ -85,7 +85,7 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options="$*"
+    options=( "$@" )
     # run flows command
     command="flows"
     ;;
@@ -99,7 +99,7 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options="$*"
+    options=( "$@" )
     # run packets command
     command="packets"
     ;;
@@ -113,7 +113,7 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options="$*"
+    options=( "$@" )
     # run metrics command
     command="metrics"
     ;;
@@ -179,7 +179,7 @@ esac
 
 trap cleanup EXIT
 
-setup $command $options
+setup
 
 if [[ "$command" == "flows" || "$command" == "packets" ]]; then
   # convert options to string

--- a/docs/netobserv_cli.adoc
+++ b/docs/netobserv_cli.adoc
@@ -61,7 +61,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
+|--enable_udn_mapping|        enable User Defined Network mapping        | false
 |--get-subnets|               get subnets information                    | false
 |--background|                run in background                          | false
 |--copy|                      copy the output files locally              | prompt
@@ -84,7 +84,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | -
 |--ports|                     filter on either of two ports              | -
 |--protocol|                  filter protocol                            | -
-|--regexes|                   filter flows using regular expression      | -
+|--query|                     filter flows using a custom query          | -
 |--sport_range|               filter source port range                   | -
 |--sport|                     filter source port                         | -
 |--sports|                    filter on either of two source ports       | -
@@ -131,7 +131,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | -
 |--ports|                     filter on either of two ports              | -
 |--protocol|                  filter protocol                            | -
-|--regexes|                   filter flows using regular expression      | -
+|--query|                     filter flows using a custom query          | -
 |--sport_range|               filter source port range                   | -
 |--sport|                     filter source port                         | -
 |--sports|                    filter on either of two source ports       | -
@@ -161,7 +161,7 @@ $ oc netobserv metrics [<option>]
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
+|--enable_udn_mapping|        enable User Defined Network mapping        | false
 |--get-subnets|               get subnets information                    | false
 |--action|                    filter action                              | Accept
 |--cidr|                      filter CIDR                                | 0.0.0.0/0
@@ -179,7 +179,7 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | -
 |--ports|                     filter on either of two ports              | -
 |--protocol|                  filter protocol                            | -
-|--regexes|                   filter flows using regular expression      | -
+|--query|                     filter flows using a custom query          | -
 |--sport_range|               filter source port range                   | -
 |--sport|                     filter source port                         | -
 |--sports|                    filter on either of two source ports       | -

--- a/e2e/integration-tests/integration_test.go
+++ b/e2e/integration-tests/integration_test.go
@@ -43,7 +43,7 @@ var _ = g.Describe("NetObserv CLI e2e integration test suite", g.Serial, func() 
 	g.It("Verify regexes filters are applied", func() {
 		// capture upto 500KB
 		nsfilter := "openshift-monitoring"
-		cliArgs := []string{"flows", "--regexes=SrcK8S_Namespace~" + nsfilter, "--copy=true", "--max-bytes=500000"}
+		cliArgs := []string{"flows", "--query=\"SrcK8S_Namespace=~" + nsfilter + "\"", "--copy=true", "--max-bytes=500000"}
 		cmd := exec.Command(ocNetObservBinPath, cliArgs...)
 		err := cmd.Run()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -70,7 +70,7 @@ var _ = g.Describe("NetObserv CLI e2e integration test suite", g.Serial, func() 
 			err := decoder.Decode(&flow)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if flow.SrcK8sNamespace != nsfilter {
-				o.Expect(true).To(o.BeFalse(), fmt.Sprintf("Flow %v does not meet regexes condition SrcK8S_Namespace~%s", flow, nsfilter))
+				o.Expect(true).To(o.BeFalse(), fmt.Sprintf("Flow %v does not meet regexes condition SrcK8S_Namespace=~%s", flow, nsfilter))
 			}
 		}
 	})

--- a/e2e/script_test.go
+++ b/e2e/script_test.go
@@ -44,7 +44,7 @@ func TestHelpCommand(t *testing.T) {
 		// ensure help to display examples
 		assert.Contains(t, str, "basic examples:")
 		assert.Contains(t, str, "netobserv flows --drops                              # Capture dropped flows on all nodes")
-		assert.Contains(t, str, "netobserv flows --regexes=SrcK8S_Namespace~app-.*    # Capture flows from any namespace starting by app-")
+		assert.Contains(t, str, "netobserv flows --query=\"SrcK8S_Namespace=~app-.*\" # Capture flows from any namespace starting by app-")
 		assert.Contains(t, str, "netobserv packets --port=8080                        # Capture packets on port 8080")
 		assert.Contains(t, str, "netobserv metrics --enable_all                       # Capture all cluster metrics including packet drop, dns, rtt, network events packet translation and UDN mapping features informations")
 		assert.Contains(t, str, "advanced examples:")

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -432,8 +432,10 @@ function overrideNetworkEnrichStage() {
 
 # update FLP Config
 function updateFLPConfig() {
-  # get json as string with escaped quotes
   jsonContent=$(cat "$1")
+  # already escaped chars must be double-escaped
+  jsonContent=${jsonContent//\\/\\\\}
+  # get json as string with escaped quotes
   jsonContent=${jsonContent//\"/\\\"}
 
   # update FLP_CONFIG env
@@ -605,13 +607,13 @@ function edit_manifest() {
       key=${keyValue[0]}
       value=${keyValue[1]}
       echo "key: $key value: $value"
-      rules+=("{\"type\":\"keep_entry_if_regex_match\",\"keepEntry\":{\"input\":\"$key\",\"value\":\"$value\"}}")
+      rules+=("$key=~\\\"$value\\\"")
     done
     rulesStr=$(
-      IFS=,
+      IFS=" and "
       echo "${rules[*]}"
     )
-    rule="{\"type\":\"keep_entry_all_satisfied\",\"keepEntryAllSatisfied\":[$rulesStr]}"
+    rule="{\"type\":\"keep_entry_query\",\"keepEntryQuery\":\"$rulesStr\"}"
 
     existingFilterStage=$("$YQ_BIN" -r ".pipeline[] | select(.name == \"filter\")" "$json")
     if [[ "$existingFilterStage" == "" ]]; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -239,7 +239,7 @@ function setup() {
   echo "Setting up... "
 
   # check for mandatory arguments
-  if ! [[ $1 =~ flows|packets|metrics ]]; then
+  if ! [[ $command =~ flows|packets|metrics ]]; then
     echo "invalid setup argument"
     return
   fi
@@ -265,7 +265,7 @@ function setup() {
       exit 1
     fi
   else
-    YAML_OUTPUT_FILE="${1}_capture_${dateName}.yml"
+    YAML_OUTPUT_FILE="${command}_capture_${dateName}.yml"
   fi
 
   # apply yamls
@@ -279,36 +279,30 @@ function setup() {
     mkdir -p ${MANIFEST_OUTPUT_PATH} >/dev/null
   fi
 
-  if [ "$1" = "flows" ]; then
+  if [ "$command" = "flows" ]; then
     echo "creating collector service"
     applyYAML "$collectorServiceYAML"
-    shift
     echo "creating flow-capture agents"
     manifest="${MANIFEST_OUTPUT_PATH}/${FLOWS_MANIFEST_FILE}"
     echo "${flowAgentYAML}" >${manifest}
     setCollectorPipelineConfig "$manifest"
-    options="$*"
-    check_args_and_apply "$options" "$manifest" "flows"
-  elif [ "$1" = "packets" ]; then
+    check_args_and_apply
+  elif [ "$command" = "packets" ]; then
     echo "creating collector service"
     applyYAML "$collectorServiceYAML"
-    shift
     echo "creating packet-capture agents"
     manifest="${MANIFEST_OUTPUT_PATH}/${PACKETS_MANIFEST_FILE}"
     echo "${packetAgentYAML}" >${manifest}
     setCollectorPipelineConfig "$manifest"
-    options="$*"
-    check_args_and_apply "$options" "$manifest" "packets"
-  elif [ "$1" = "metrics" ]; then
+    check_args_and_apply
+  elif [ "$command" = "metrics" ]; then
     echo "creating service monitor"
     applyYAML "$smYAML"
-    shift
     echo "creating metric-capture agents:"
     manifest="${MANIFEST_OUTPUT_PATH}/${METRICS_MANIFEST_FILE}"
     echo "${metricAgentYAML}" >${manifest}
     setMetricsPipelineConfig "$manifest"
-    options="$*"
-    check_args_and_apply "$options" "$manifest" "metrics"
+    check_args_and_apply
   fi
 }
 
@@ -466,47 +460,47 @@ function edit_manifest() {
     echo "opt: $1, value: $2"
   fi
 
-  if [[ $1 == "filter_"* && $1 != "filter_regexes" ]]; then
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_FLOW_FILTER\").value|=\"true\"" "$3"
+  if [[ $1 == "filter_"* && $1 != "filter_query" ]]; then
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_FLOW_FILTER\").value|=\"true\"" "$manifest"
     # add first filter in the array
-    currentFilters=$("$YQ_BIN" -r ".spec.template.spec.containers[0].env[] | select(.name == \"FLOW_FILTER_RULES\").value" "$3")
+    currentFilters=$("$YQ_BIN" -r ".spec.template.spec.containers[0].env[] | select(.name == \"FLOW_FILTER_RULES\").value" "$manifest")
     if [[ $currentFilters == "[]" ]]; then
-      addFlowFilter "$3"
+      addFlowFilter "$manifest"
     fi
   fi
 
   case "$1" in
   "interfaces")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"INTERFACES\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"INTERFACES\").value|=\"$2\"" "$manifest"
     ;;
   "pkt_drop_enable")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_PKT_DROPS\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_PKT_DROPS\").value|=\"$2\"" "$manifest"
     ;;
   "dns_enable")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_DNS_TRACKING\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_DNS_TRACKING\").value|=\"$2\"" "$manifest"
     ;;
   "rtt_enable")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_RTT\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_RTT\").value|=\"$2\"" "$manifest"
     ;;
   "network_events_enable")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_NETWORK_EVENTS_MONITORING\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_NETWORK_EVENTS_MONITORING\").value|=\"$2\"" "$manifest"
     ;;
   "udn_enable")
     if [[ "$2" == "true" ]]; then
       # add udn to secondary network indexes
-      copyFLPConfig "$3"
+      copyFLPConfig "$manifest"
       getNetworkEnrichStage
 
       # add kubeConfig.secondaryNetworks to network
       "$YQ_BIN" e -oj --inplace ".transform.network.kubeConfig = {\"secondaryNetworks\":[{\"name\":\"ovn-kubernetes\",\"index\":{\"udn\":null}}]}" "$enrichJson"
 
       overrideNetworkEnrichStage
-      updateFLPConfig "$json" "$3"
+      updateFLPConfig "$json" "$manifest"
     fi
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_UDN_MAPPING\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_UDN_MAPPING\").value|=\"$2\"" "$manifest"
     ;;
   "pkt_xlat_enable")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_PKT_TRANSLATION\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_PKT_TRANSLATION\").value|=\"$2\"" "$manifest"
     ;;
   "get_subnets")
     if [[ "$2" == "true" ]]; then
@@ -514,7 +508,7 @@ function edit_manifest() {
       getSubnets subnets
 
       if [ "${#subnets[@]}" -gt 0 ]; then
-        copyFLPConfig "$3"
+        copyFLPConfig "$manifest"
         getNetworkEnrichStage
 
         # add rules to network
@@ -528,92 +522,80 @@ function edit_manifest() {
         done
 
         overrideNetworkEnrichStage
-        updateFLPConfig "$json" "$3"
+        updateFLPConfig "$json" "$manifest"
       fi
     fi
     ;;
   "add_filter")
-    addFlowFilter "$3"
+    addFlowFilter "$manifest"
     ;;
   "filter_direction")
-    setLastFlowFilter "direction" "\"$2\"" "$3"
+    setLastFlowFilter "direction" "\"$2\"" "$manifest"
     ;;
   "filter_cidr")
-    setLastFlowFilter "ip_cidr" "\"$2\"" "$3"
+    setLastFlowFilter "ip_cidr" "\"$2\"" "$manifest"
     ;;
   "filter_protocol")
-    setLastFlowFilter "protocol" "\"$2\"" "$3"
+    setLastFlowFilter "protocol" "\"$2\"" "$manifest"
     ;;
   "filter_sport")
-    setLastFlowFilter "source_port" = "$2" "$3"
+    setLastFlowFilter "source_port" = "$2" "$manifest"
     ;;
   "filter_dport")
-    setLastFlowFilter "destination_port" "$2" "$3"
+    setLastFlowFilter "destination_port" "$2" "$manifest"
     ;;
   "filter_port")
-    setLastFlowFilter "port" "$2" "$3"
+    setLastFlowFilter "port" "$2" "$manifest"
     ;;
   "filter_sport_range")
-    setLastFlowFilter "source_port_range" "\"$2\"" "$3"
+    setLastFlowFilter "source_port_range" "\"$2\"" "$manifest"
     ;;
   "filter_dport_range")
-    setLastFlowFilter "destination_port_range" "\"$2\"" "$3"
+    setLastFlowFilter "destination_port_range" "\"$2\"" "$manifest"
     ;;
   "filter_port_range")
-    setLastFlowFilter "port_range" "\"$2\"" "$3"
+    setLastFlowFilter "port_range" "\"$2\"" "$manifest"
     ;;
   "filter_sports")
-    setLastFlowFilter "source_ports" "\"$2\"" "$3"
+    setLastFlowFilter "source_ports" "\"$2\"" "$manifest"
     ;;
   "filter_dports")
-    setLastFlowFilter "destination_ports" "\"$2\"" "$3"
+    setLastFlowFilter "destination_ports" "\"$2\"" "$manifest"
     ;;
   "filter_ports")
-    setLastFlowFilter "ports" "\"$2\"" "$3"
+    setLastFlowFilter "ports" "\"$2\"" "$manifest"
     ;;
   "filter_icmp_type")
-    setLastFlowFilter "icmp_type" "$2" "$3"
+    setLastFlowFilter "icmp_type" "$2" "$manifest"
     ;;
   "filter_icmp_code")
-    setLastFlowFilter "icmp_code" "$2" "$3"
+    setLastFlowFilter "icmp_code" "$2" "$manifest"
     ;;
   "filter_peer_ip")
-    setLastFlowFilter "peer_ip" "\"$2\"" "$3"
+    setLastFlowFilter "peer_ip" "\"$2\"" "$manifest"
     ;;
   "filter_peer_cidr")
-    setLastFlowFilter "peer_cidr" "\"$2\"" "$3"
+    setLastFlowFilter "peer_cidr" "\"$2\"" "$manifest"
     ;;
   "filter_action")
-    setLastFlowFilter "action" "\"$2\"" "$3"
+    setLastFlowFilter "action" "\"$2\"" "$manifest"
     ;;
   "filter_tcp_flags")
-    setLastFlowFilter "tcp_flags" "\"$2\"" "$3"
+    setLastFlowFilter "tcp_flags" "\"$2\"" "$manifest"
     ;;
   "filter_pkt_drops")
     if [[ "$2" == "true" ]]; then
       # force enable drops before setting filter
-      edit_manifest "pkt_drop_enable" "$2" "$3"
+      edit_manifest "pkt_drop_enable" "$2" "$manifest"
     fi
-    setLastFlowFilter "drops" "$2" "$3"
+    setLastFlowFilter "drops" "$2" "$manifest"
     ;;
-  "filter_regexes")
-    copyFLPConfig "$3"
+  "filter_query")
+    copyFLPConfig "$manifest"
 
     # define rules from arg
-    IFS=',' read -ra regexes <<<"$2"
-    rules=()
-    for regex in "${regexes[@]}"; do
-      IFS='~' read -ra keyValue <<<"$regex"
-      key=${keyValue[0]}
-      value=${keyValue[1]}
-      echo "key: $key value: $value"
-      rules+=("$key=~\\\"$value\\\"")
-    done
-    rulesStr=$(
-      IFS=" and "
-      echo "${rules[*]}"
-    )
-    rule="{\"type\":\"keep_entry_query\",\"keepEntryQuery\":\"$rulesStr\"}"
+    query=${2//\"/\\\"}
+    rule="{\"type\":\"keep_entry_query\",\"keepEntryQuery\":\"$query\"}"
 
     existingFilterStage=$("$YQ_BIN" -r ".pipeline[] | select(.name == \"filter\")" "$json")
     if [[ "$existingFilterStage" == "" ]]; then
@@ -631,10 +613,10 @@ function edit_manifest() {
       "$YQ_BIN" e --inplace " .parameters[] |= select(.name == \"filter\").transform.filter.rules += $rule" "$json"
     fi
 
-    updateFLPConfig "$json" "$3"
+    updateFLPConfig "$json" "$manifest"
     ;;
   "log_level")
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"LOG_LEVEL\").value|=\"$2\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"LOG_LEVEL\").value|=\"$2\"" "$manifest"
     ;;
   "node_selector")
     key=${2%:*}
@@ -642,14 +624,13 @@ function edit_manifest() {
     if [[ "$outputYAML" == "false" ]]; then
       getNodesByLabel "$key=$val"
     fi
-    "$YQ_BIN" e --inplace ".spec.template.spec.nodeSelector.\"$key\" |= \"$val\"" "$3"
+    "$YQ_BIN" e --inplace ".spec.template.spec.nodeSelector.\"$key\" |= \"$val\"" "$manifest"
     ;;
   esac
 }
 
 # define key and value at script level to make them available all the time
 # these will be updated by check_args_and_apply first and overriden by defaultValue when needed
-prevKey=""
 key=""
 value=""
 
@@ -659,21 +640,15 @@ function defaultValue() {
   fi
 }
 
-# Check if the arguments are valid
-#$1: options
-#$2: manifest
-#$3: flows, packets or metrics
+# Check if $options are valid
 function check_args_and_apply() {
   # Iterate through the command-line arguments
-  for option in $1; do
-    prevKey="$key"
+  for option in "${options[@]}"; do
     key="${option%%=*}"
     value="${option#*=}"
     case "$key" in
     or) # Increment flow filter array
-      if [[ "$prevKey" != *regexes ]]; then
-        edit_manifest "add_filter" "" "$2"
-      fi
+      edit_manifest "add_filter" ""
       ;;
     *background) # Run command in background
       defaultValue "true"
@@ -694,13 +669,13 @@ function check_args_and_apply() {
       fi
       ;;
     *interfaces) # Interfaces
-      edit_manifest "interfaces" "$value" "$2"
+      edit_manifest "interfaces" "$value"
       ;;
     *enable_pkt_drop) # Enable packet drop
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "pkt_drop_enable" "$value" "$2"
+          edit_manifest "pkt_drop_enable" "$value"
         else
           echo "invalid value for --enable_pkt_drop"
         fi
@@ -710,10 +685,10 @@ function check_args_and_apply() {
       fi
       ;;
     *enable_dns) # Enable DNS
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "dns_enable" "$value" "$2"
+          edit_manifest "dns_enable" "$value"
         else
           echo "invalid value for --enable_dns"
         fi
@@ -723,10 +698,10 @@ function check_args_and_apply() {
       fi
       ;;
     *enable_rtt) # Enable RTT
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "rtt_enable" "$value" "$2"
+          edit_manifest "rtt_enable" "$value"
         else
           echo "invalid value for --enable_rtt"
         fi
@@ -736,10 +711,10 @@ function check_args_and_apply() {
       fi
       ;;
     *enable_network_events) # Enable Network events monitoring
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "network_events_enable" "$value" "$2"
+          edit_manifest "network_events_enable" "$value"
         else
           echo "invalid value for --enable_network_events"
         fi
@@ -749,10 +724,10 @@ function check_args_and_apply() {
       fi
       ;;
     *enable_udn_mapping) # Enable User Defined Network mapping
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "udn_enable" "$value" "$2"
+          edit_manifest "udn_enable" "$value"
         else
           echo "invalid value for --enable_udn_mapping"
         fi
@@ -762,10 +737,10 @@ function check_args_and_apply() {
       fi
       ;;
     *enable_pkt_translation) # Enable Packet translation
-      if [[ "$3" == "flows" || "$3" == "metrics" ]]; then
+      if [[ "$command" == "flows" || "$command" == "metrics" ]]; then
         defaultValue "true"
         if [[ "$value" == "true" || "$value" == "false" ]]; then
-          edit_manifest "pkt_xlat_enable" "$value" "$2"
+          edit_manifest "pkt_xlat_enable" "$value"
         else
           echo "invalid value for --enable_pkt_translation"
         fi
@@ -777,66 +752,66 @@ function check_args_and_apply() {
     *enable_all) # Enable all features
       defaultValue "true"
       if [[ "$value" == "true" || "$value" == "false" ]]; then
-        edit_manifest "pkt_drop_enable" "$value" "$2"
-        edit_manifest "dns_enable" "$value" "$2"
-        edit_manifest "rtt_enable" "$value" "$2"
-        edit_manifest "network_events_enable" "$value" "$2"
-        edit_manifest "udn_enable" "$value" "$2"
-        edit_manifest "pkt_xlat_enable" "$value" "$2"
+        edit_manifest "pkt_drop_enable" "$value"
+        edit_manifest "dns_enable" "$value"
+        edit_manifest "rtt_enable" "$value"
+        edit_manifest "network_events_enable" "$value"
+        edit_manifest "udn_enable" "$value"
+        edit_manifest "pkt_xlat_enable" "$value"
       else
         echo "invalid value for --enable_all"
       fi
       ;;
     *direction) # Configure filter direction
       if [[ "$value" == "Ingress" || "$value" == "Egress" ]]; then
-        edit_manifest "filter_direction" "$value" "$2"
+        edit_manifest "filter_direction" "$value"
       else
         echo "invalid value for --direction"
       fi
       ;;
     *peer_cidr) # Peer CIDR
-      edit_manifest "filter_peer_cidr" "$value" "$2"
+      edit_manifest "filter_peer_cidr" "$value"
       ;;
     *cidr) # Configure flow CIDR
-      edit_manifest "filter_cidr" "$value" "$2"
+      edit_manifest "filter_cidr" "$value"
       ;;
     *protocol) # Configure filter protocol
       if [[ "$value" == "TCP" || "$value" == "UDP" || "$value" == "SCTP" || "$value" == "ICMP" || "$value" == "ICMPv6" ]]; then
-        edit_manifest "filter_protocol" "$value" "$2"
+        edit_manifest "filter_protocol" "$value"
       else
         echo "invalid value for --protocol"
       fi
       ;;
     *sport) # Configure filter source port
-      edit_manifest "filter_sport" "$value" "$2"
+      edit_manifest "filter_sport" "$value"
       ;;
     *dport) # Configure filter destination port
-      edit_manifest "filter_dport" "$value" "$2"
+      edit_manifest "filter_dport" "$value"
       ;;
     *port) # Configure filter port
-      edit_manifest "filter_port" "$value" "$2"
+      edit_manifest "filter_port" "$value"
       ;;
     *sport_range) # Configure filter source port range
-      edit_manifest "filter_sport_range" "$value" "$2"
+      edit_manifest "filter_sport_range" "$value"
       ;;
     *dport_range) # Configure filter destination port range
-      edit_manifest "filter_dport_range" "$value" "$2"
+      edit_manifest "filter_dport_range" "$value"
       ;;
     *port_range) # Configure filter port range
-      edit_manifest "filter_port_range" "$value" "$2"
+      edit_manifest "filter_port_range" "$value"
       ;;
     *sports) # Configure filter source two ports using ","
-      edit_manifest "filter_sports" "$value" "$2"
+      edit_manifest "filter_sports" "$value"
       ;;
     *dports) # Configure filter destination two ports using ","
-      edit_manifest "filter_dports" "$value" "$2"
+      edit_manifest "filter_dports" "$value"
       ;;
     *ports) # Configure filter on two ports usig "," can either be srcport or dstport
-      edit_manifest "filter_ports" "$value" "$2"
+      edit_manifest "filter_ports" "$value"
       ;;
     *tcp_flags) # Configure filter TCP flags
       if [[ "$value" == "SYN" || "$value" == "SYN-ACK" || "$value" == "ACK" || "$value" == "FIN" || "$value" == "RST" || "$value" == "FIN-ACK" || "$value" == "RST-ACK" || "$value" == "PSH" || "$value" == "URG" || "$value" == "ECE" || "$value" == "CWR" ]]; then
-        edit_manifest "filter_tcp_flags" "$value" "$2"
+        edit_manifest "filter_tcp_flags" "$value"
       else
         echo "invalid value for --tcp_flags"
       fi
@@ -844,39 +819,38 @@ function check_args_and_apply() {
     *drops) # Filter packet drops
       defaultValue "true"
       if [[ "$value" == "true" || "$value" == "false" ]]; then
-        edit_manifest "filter_pkt_drops" "$value" "$2"
+        edit_manifest "filter_pkt_drops" "$value"
       else
         echo "invalid value for --drops"
       fi
       ;;
-    *regexes) # Filter using regexes
-      valueCount=$(grep -o "~" <<<"$value" | wc -l)
-      splitterCount=$(grep -o "," <<<"$value" | wc -l)
-      if [[ ${valueCount} -gt 0 && $((valueCount)) == $((splitterCount + 1)) ]]; then
-        edit_manifest "filter_regexes" "$value" "$2"
+    *query) # Filter using a custom query
+      if [[ "$value" != "" ]]; then
+        edit_manifest "filter_query" "$value"
       else
-        echo "invalid value for --regexes"
+        echo "missing value for --query"
+        exit 1
       fi
       ;;
     *icmp_type) # ICMP type
-      edit_manifest "filter_icmp_type" "$value" "$2"
+      edit_manifest "filter_icmp_type" "$value"
       ;;
     *icmp_code) # ICMP code
-      edit_manifest "filter_icmp_code" "$value" "$2"
+      edit_manifest "filter_icmp_code" "$value"
       ;;
     *peer_ip) # Peer IP
-      edit_manifest "filter_peer_ip" "$value" "$2"
+      edit_manifest "filter_peer_ip" "$value"
       ;;
     *action) # Filter action
       if [[ "$value" == "Accept" || "$value" == "Reject" ]]; then
-        edit_manifest "filter_action" "$value" "$2"
+        edit_manifest "filter_action" "$value"
       else
         echo "invalid value for --action"
       fi
       ;;
     *log-level) # Log level
       if [[ "$value" == "trace" || "$value" == "debug" || "$value" == "info" || "$value" == "warn" || "$value" == "error" || "$value" == "fatal" || "$value" == "panic" ]]; then
-        edit_manifest "log_level" "$value" "$2"
+        edit_manifest "log_level" "$value"
         logLevel=$value
         filter=${filter/$key=$logLevel/}
       else
@@ -893,7 +867,7 @@ function check_args_and_apply() {
       ;;
     *node-selector) # Node selector
       if [[ $value == *":"* ]]; then
-        edit_manifest "node_selector" "$value" "$2"
+        edit_manifest "node_selector" "$value"
       else
         echo "invalid value for --node-selector. Use --node-selector=key:val instead."
         exit 1
@@ -902,7 +876,7 @@ function check_args_and_apply() {
     *get-subnets) # Get subnets
       defaultValue "true"
       if [[ "$value" == "true" || "$value" == "false" ]]; then
-        edit_manifest "get_subnets" "$value" "$2"
+        edit_manifest "get_subnets" "$value"
       else
         echo "invalid value for --get-subnets"
       fi
@@ -915,8 +889,8 @@ function check_args_and_apply() {
   done
 
   # avoid packet capture without filters
-  if [[ "$3" = "packets" ]]; then
-    currentFilters=$("$YQ_BIN" -r ".spec.template.spec.containers[0].env[] | select(.name == \"FLOW_FILTER_RULES\").value" "$2")
+  if [[ "$command" = "packets" ]]; then
+    currentFilters=$("$YQ_BIN" -r ".spec.template.spec.containers[0].env[] | select(.name == \"FLOW_FILTER_RULES\").value" "$manifest")
     if [[ $currentFilters == "[]" ]]; then
       echo
       echo "Error: At least one eBPF filter must be set for packet capture to avoid high resource consumption."
@@ -926,7 +900,7 @@ function check_args_and_apply() {
     fi
   fi
 
-  yaml="$(cat "$2")"
+  yaml="$(cat "$manifest")"
   applyYAML "$yaml"
   if [[ "$outputYAML" == "false" ]]; then
     ${K8S_CLI_BIN} rollout status daemonset netobserv-cli -n "$namespace" --timeout 60s

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -44,6 +44,11 @@ if [ -n "$NETOBSERV_AGENT_IMAGE" ]; then
   agentImg="$NETOBSERV_AGENT_IMAGE"
 fi
 
+# globals populated from calling script
+command=""
+options=""
+manifest=""
+
 OUTPUT_PATH="./output"
 YAML_OUTPUT_FILE="capture.yml"
 MANIFEST_OUTPUT_PATH="tmp"

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -21,10 +21,10 @@ function help {
   echo "  version    Print software version."
   echo
   echo "basic examples:"
-  echo "  netobserv flows --drops                              # Capture dropped flows on all nodes"
-  echo "  netobserv flows --regexes=SrcK8S_Namespace~app-.*    # Capture flows from any namespace starting by app-"
-  echo "  netobserv packets --port=8080                        # Capture packets on port 8080"
-  echo "  netobserv metrics --enable_all                       # Capture all cluster metrics including packet drop, dns, rtt, network events packet translation and UDN mapping features informations"
+  echo "  netobserv flows --drops                                     # Capture dropped flows on all nodes"
+  echo "  netobserv flows --query='SrcK8S_Namespace=~\"app-.*\"'        # Capture flows from any namespace starting by app-"
+  echo "  netobserv packets --port=8080                               # Capture packets on port 8080"
+  echo "  netobserv metrics --enable_all                              # Capture all cluster metrics including packet drop, dns, rtt, network events packet translation and UDN mapping features informations"
   echo
   echo "advanced examples:"
   echo "  Capture drops in background and copy output locally"
@@ -40,8 +40,8 @@ function help {
   echo "  Capture flows from a specific pod"
   echo "    netobserv flows                                           # Capture flows"
   echo "    --node-selector=kubernetes.io/hostname:my-node            # on node matching label 'kubernetes.io/hostname=my-node'"
-  echo "    --regexes=SrcK8S_Name~.*my-pod.*                          # from any pod name containing 'my-pod'"
-  echo "    or --regexes=DstK8S_Name~.*my-pod.*                       # or to any pod name containing 'my-pod'"
+  echo "    --query='SrcK8S_Name=~\".*my-pod.*\"                        # from any pod name containing 'my-pod'"
+  echo "             or DstK8S_Name=~\".*my-pod.*\"'                    # or to any pod name containing 'my-pod'"
   echo
   echo "  Capture packets on specific nodes and port"
   echo "    netobserv packets                                         # Capture packets"
@@ -64,7 +64,7 @@ function features_usage {
   echo "  --enable_pkt_translation:     enable packet translation                  (default: false)"
   echo "  --enable_pkt_drop:            enable packet drop                         (default: false)"
   echo "  --enable_rtt:                 enable RTT tracking                        (default: false)"
-  echo "  --enable_udn_mapping:         enable User Defined Network mapping (default: false)"
+  echo "  --enable_udn_mapping:         enable User Defined Network mapping        (default: false)"
   echo "  --get-subnets:                get subnets information                    (default: false)"
 }
 
@@ -100,7 +100,7 @@ function filters_usage {
   echo "  --port:                       filter port                                (default: n/a)"
   echo "  --ports:                      filter on either of two ports              (default: n/a)"
   echo "  --protocol:                   filter protocol                            (default: n/a)"
-  echo "  --regexes:                    filter flows using regular expression      (default: n/a)"
+  echo "  --query:                      filter flows using a custom query          (default: n/a)"
   echo "  --sport_range:                filter source port range                   (default: n/a)"
   echo "  --sport:                      filter source port                         (default: n/a)"
   echo "  --sports:                     filter on either of two source ports       (default: n/a)"


### PR DESCRIPTION
See https://github.com/netobserv/flowlogs-pipeline/pull/930

## Description

Run with FLP queries (e.g.) :

```bash
make flows COMMAND_ARGS="--query='DstK8S_Namespace=~\"openshift.*\"'"

# or with installed plugin:
oc netobserv flows --query='DstK8S_Namespace=~"openshift.*"'
```

For more info on the query language: https://github.com/netobserv/flowlogs-pipeline/blob/main/docs/filtering.md

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
