### PR TITLE
Backport NETOBSERV-2257: identify interfaces by index and mac

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -37,6 +37,8 @@ spec:
             value: ""
           - name: EXCLUDE_INTERFACES
             value: "lo"
+          - name: PREFERRED_INTERFACE_FOR_MAC_PREFIX
+            value: "0a:58=eth0"
           - name: SAMPLING
             value: "1"
           - name: ENABLE_RTT


### PR DESCRIPTION
Backport of https://github.com/netobserv/network-observability-cli/pull/308