### PR TITLE
NETOBSERV-2253 CLI: enhance metrics safety option

### DIFF
--- a/cmd/metric_capture.go
+++ b/cmd/metric_capture.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var metricCmd = &cobra.Command{
+	Use:   "get-metrics",
+	Short: "",
+	Long:  "",
+	Run:   runMetricCapture,
+}
+
+func runMetricCapture(_ *cobra.Command, _ []string) {
+	captureType = "Metric"
+
+	// TODO: implement a UI for metrics using tview
+	// https://github.com/netobserv/network-observability-cli/pull/215
+
+	ticker := time.NewTicker(time.Second)
+	for range ticker.C {
+		// terminate capture if max time reached
+		now := currentTime()
+		duration := now.Sub(startupTime)
+		if int(duration) > int(maxTime) {
+			log.Infof("Capture reached %s, exiting now...", maxTime)
+
+			if allowClear {
+				resetTerminal()
+			}
+			out, err := exec.Command("/oc-netobserv", "stop").Output()
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("%s", out)
+			fmt.Print(`Thank you for using...`)
+			printBanner()
+			fmt.Print(`
+
+  - Open NetObserv / On Demand dashboard to see generated metrics
+
+	- Once finished, remove everything using 'oc netobserv cleanup'
+
+                                                      See you soon !
+																											
+																											
+		`)
+			return
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,11 +74,14 @@ func init() {
 		os.Exit(0)
 	}()
 
-	// IPFIX flow
+	// flow
 	rootCmd.AddCommand(flowCmd)
 
 	// packet
 	rootCmd.AddCommand(pktCmd)
+
+	// metrics
+	rootCmd.AddCommand(metricCmd)
 }
 
 func onInit() {

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -253,7 +253,7 @@ if [[ "$command" == "flows" || "$command" == "packets" || "$command" == "metrics
     echo "Metrics capture started."
     consoleURL="$(oc whoami --show-console)"
     echo "Open ${consoleURL}/monitoring/dashboards/netobserv-cli to see generated metrics."
-    echo "Use 'oc netobserv stop' to stop the collection and 'oc netobserv cleanup' to remove everything."
+    echo "Use '${K8S_CLI_BIN} netobserv stop' to stop the collection and 'oc netobserv cleanup' to remove everything."
     echo
     echo "Capture ends automatically in $maxTime"
   fi

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -255,7 +255,7 @@ if [[ "$command" == "flows" || "$command" == "packets" || "$command" == "metrics
     echo "Open ${consoleURL}/monitoring/dashboards/netobserv-cli to see generated metrics."
     echo "Use 'oc netobserv stop' to stop the collection and 'oc netobserv cleanup' to remove everything."
     echo
-    echo "Capture end automatically in $maxTime"
+    echo "Capture ends automatically in $maxTime"
   fi
 else
   echo "Unexpected exception occured on $command"

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -247,7 +247,7 @@ if [[ "$command" == "flows" || "$command" == "packets" || "$command" == "metrics
     echo " - '${K8S_CLI_BIN} netobserv copy' to copy the generated files locally"
     echo " - '${K8S_CLI_BIN} netobserv cleanup' to remove the netobserv components"
     echo
-    echo "Capture end automatically in $maxTime or reaching $maxBytes bytes"
+    echo "Capture ends automatically in $maxTime or reaching $maxBytes bytes"
   else
     runBackground="true"
     echo "Metrics capture started."

--- a/commands/netobserv
+++ b/commands/netobserv
@@ -85,7 +85,7 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options=( "$@" )
+    options=("$@")
     # run flows command
     command="flows"
     ;;
@@ -99,7 +99,7 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options=( "$@" )
+    options=("$@")
     # run packets command
     command="packets"
     ;;
@@ -113,9 +113,11 @@ case "$1" in
     ;;
   *)
     shift # remove first argument
-    options=( "$@" )
+    options=("$@")
     # run metrics command
     command="metrics"
+    # override maxTime default to 1h for metrics only
+    maxTime="1h"
     ;;
   esac
   ;;
@@ -181,7 +183,7 @@ trap cleanup EXIT
 
 setup
 
-if [[ "$command" == "flows" || "$command" == "packets" ]]; then
+if [[ "$command" == "flows" || "$command" == "packets" || "$command" == "metrics" ]]; then
   # convert options to string
   optionStr="${options//--/}"
   optionStr="${optionStr// /|}"
@@ -189,7 +191,7 @@ if [[ "$command" == "flows" || "$command" == "packets" ]]; then
   # prepare commands & args
   runCommand="sleep infinity"
   execCommand="/network-observability-cli get-$command ${optionStr:+"--options" "${optionStr}"} --loglevel $logLevel --maxtime $maxTime --maxbytes $maxBytes"
-  if [[ "$runBackground" == "true" || "$outputYAML" == "true" ]]; then
+  if [[ "$runBackground" == "true" || "$outputYAML" == "true" || "$command" == "metrics" ]]; then
     runCommand="bash -c \"$execCommand && $runCommand\""
     execCommand=""
   fi
@@ -199,18 +201,29 @@ if [[ "$command" == "flows" || "$command" == "packets" ]]; then
   --command -- $runCommand"
 
   if [[ "$outputYAML" == "true" ]]; then
-    echo "Check the generated YAML file in output folder."
-    echo
-    echo "You can create $command agents by executing:"
-    echo " ${K8S_CLI_BIN} apply -f ./output/${command}_capture_${dateName}.yml"
-    echo
-    echo "Then create the collector using:"
-    echo -e " $cmd"
-    echo
-    echo "And follow its progression with:"
-    echo " ${K8S_CLI_BIN} logs collector -n $namespace -f"
-    echo
-    exit 0
+    if [[ "$command" == "flows" || "$command" == "packets" ]]; then
+      echo "Check the generated YAML file in output folder."
+      echo
+      echo "You can create $command agents by executing:"
+      echo " ${K8S_CLI_BIN} apply -f ./output/${command}_capture_${dateName}.yml"
+      echo
+      echo "Then create the collector using:"
+      echo -e " $cmd"
+      echo
+      echo "And follow its progression with:"
+      echo " ${K8S_CLI_BIN} logs collector -n $namespace -f"
+      echo
+      exit 0
+    else
+      echo "Check the generated YAML file in output folder."
+      echo
+      echo "You can create metrics agents by executing:"
+      echo " ${K8S_CLI_BIN} apply -f ./output/${command}_capture_${dateName}.yml"
+      echo
+      echo "Then open your OCP Console and search for netobserv-cli dashboard"
+      echo
+      exit 0
+    fi
   fi
 
   echo "Running network-observability-cli get-$cmd... "
@@ -228,28 +241,22 @@ if [[ "$command" == "flows" || "$command" == "packets" ]]; then
       -n $namespace \
       collector \
       -- $execCommand
-  else
+  elif [[ "$command" == "flows" || "$command" == "packets" ]]; then
     echo "Background capture started. Use:"
     echo " - '${K8S_CLI_BIN} netobserv follow' to see the capture progress"
     echo " - '${K8S_CLI_BIN} netobserv copy' to copy the generated files locally"
     echo " - '${K8S_CLI_BIN} netobserv cleanup' to remove the netobserv components"
-  fi
-elif [ "$command" = "metrics" ]; then
-  if [[ "$outputYAML" == "true" ]]; then
-    echo "Check the generated YAML file in output folder."
     echo
-    echo "You can create metrics agents by executing:"
-    echo " ${K8S_CLI_BIN} apply -f ./output/${command}_capture_${dateName}.yml"
-    echo 
-    echo "Then open your OCP Console and search for netobserv-cli dashboard"
+    echo "Capture end automatically in $maxTime or reaching $maxBytes bytes"
+  else
+    runBackground="true"
+    echo "Metrics capture started."
+    consoleURL="$(oc whoami --show-console)"
+    echo "Open ${consoleURL}/monitoring/dashboards/netobserv-cli to see generated metrics."
+    echo "Use 'oc netobserv stop' to stop the collection and 'oc netobserv cleanup' to remove everything."
     echo
-    exit 0
+    echo "Capture end automatically in $maxTime"
   fi
-  runBackground="true"
-  echo "Metrics capture started."
-  consoleURL="$(oc whoami --show-console)"
-  echo "Open ${consoleURL}/monitoring/dashboards/netobserv-cli to see generated metrics."
-  echo "Use 'oc netobserv stop' to stop the collection and 'oc netobserv cleanup' to remove everything."
 else
   echo "Unexpected exception occured on $command"
   exit 1

--- a/docs/netobserv_cli.adoc
+++ b/docs/netobserv_cli.adoc
@@ -168,6 +168,7 @@ $ oc netobserv metrics [<option>]
 |--enable_udn_mapping|        enable User Defined Network mapping                   | false
 |--get-subnets|               get subnets information                               | false
 |--sampling|                  value that defines the ratio of packets being sampled | 1
+|--max-time|                  maximum capture time                                  | 1h
 |--action|                    filter action                                         | Accept
 |--cidr|                      filter CIDR                                           | 0.0.0.0/0
 |--direction|                 filter direction                                      | -

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -970,8 +970,13 @@ function check_args_and_apply() {
       filter=${filter/$key=$maxTime/}
       ;;
     *max-bytes) # Max bytes
-      maxBytes=$value
-      filter=${filter/$key=$maxBytes/}
+      if [[ "$command" == "flows" || "$command" == "packets" ]]; then
+        maxBytes=$value
+        filter=${filter/$key=$maxBytes/}
+      else 
+        echo "--max-bytes is invalid option for metrics"
+        exit 1
+      fi
       ;;
     *node-selector) # Node selector
       if [[ $value == *":"* ]]; then

--- a/scripts/generate-doc.sh
+++ b/scripts/generate-doc.sh
@@ -66,7 +66,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |===
 | Option | Description | Default"
 features_usage
-collector_usage
+flowsAndPackets_collector_usage
 filters_usage
 flowsAndMetrics_filters_usage
 echo -e "|==="
@@ -92,7 +92,7 @@ $ oc netobserv packets [<option>]
 [cols=\"1,1,1\",options=\"header\"]
 |===
 | Option | Description | Default"
-collector_usage
+flowsAndPackets_collector_usage
 filters_usage
 echo -e "|==="
 # packets example
@@ -117,6 +117,7 @@ $ oc netobserv metrics [<option>]
 |===
 | Option | Description | Default"
 features_usage
+metrics_collector_usage
 filters_usage
 metrics_options
 flowsAndMetrics_filters_usage

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -78,13 +78,18 @@ function features_usage {
   echo "  --sampling:                   value that defines the ratio of packets being sampled (default: 1)"
 }
 
-# collector options
-function collector_usage {
+# flow and packets collector options
+function flowsAndPackets_collector_usage {
   echo "  --background:                 run in background                                     (default: false)"
   echo "  --copy:                       copy the output files locally                         (default: prompt)"
   echo "  --log-level:                  components logs                                       (default: info)"
   echo "  --max-time:                   maximum capture time                                  (default: 5m)"
   echo "  --max-bytes:                  maximum capture bytes                                 (default: 50000000 = 50MB)"
+}
+
+# fmetrics collector options
+function metrics_collector_usage {
+  echo "  --max-time:                   maximum capture time                                  (default: 1h)"
 }
 
 # script options
@@ -143,7 +148,7 @@ function flows_usage {
   flowsAndMetrics_filters_usage
   echo
   echo "options:"
-  collector_usage
+  flowsAndPackets_collector_usage
   script_usage
 }
 
@@ -158,7 +163,7 @@ function packets_usage {
   filters_usage
   echo
   echo "options:"
-  collector_usage
+  flowsAndPackets_collector_usage
   script_usage
 }
 
@@ -176,6 +181,7 @@ function metrics_usage {
   filters_usage
   flowsAndMetrics_filters_usage
   echo "options:"
+  metrics_collector_usage
   script_usage
   metrics_options
   echo


### PR DESCRIPTION
## Description

- deploy collector when running metrics to force a maximum time

For now, the collector is only used as cleanup pod that removes the agents when the limit is reached.
In the future, that pod could handle more limits and even consume the generated metrics and expose these in the display using tview https://github.com/netobserv/network-observability-cli/pull/215

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
