### PR TITLE
[NETOBSERV-2274] Remove ENABLE_FLOW_FILTER environment variable 

### DIFF
--- a/res/flow-capture.yml
+++ b/res/flow-capture.yml
@@ -55,8 +55,6 @@ spec:
             value: "false"
           - name: ENABLE_IPSEC_TRACKING
             value: "false"
-          - name: ENABLE_FLOW_FILTER
-            value: "false"
           - name: FLOW_FILTER_RULES
             value: >-
               []

--- a/res/metric-capture.yml
+++ b/res/metric-capture.yml
@@ -49,8 +49,6 @@ spec:
             value: "false"
           - name: ENABLE_PKT_TRANSLATION
             value: "false"
-          - name: ENABLE_FLOW_FILTER
-            value: "false"
           - name: FLOW_FILTER_RULES
             value: >-
               []

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -479,7 +479,6 @@ function edit_manifest() {
   fi
 
   if [[ $1 == "filter_"* && $1 != "filter_query" ]]; then
-    "$YQ_BIN" e --inplace ".spec.template.spec.containers[0].env[] |= select(.name==\"ENABLE_FLOW_FILTER\").value|=\"true\"" "$manifest"
     # add first filter in the array
     currentFilters=$("$YQ_BIN" -r ".spec.template.spec.containers[0].env[] | select(.name == \"FLOW_FILTER_RULES\").value" "$manifest")
     if [[ $currentFilters == "[]" ]]; then


### PR DESCRIPTION
## Description

ENABLE_FLOW_FILTER environment variable is not required anymore.

Ref: https://issues.redhat.com/browse/NETOBSERV-2274

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
