### PR TITLE
NETOBSERV-2358 exit on daemonset failure with logs

### DIFF
--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -710,7 +710,7 @@ function waitDaemonset(){
         required=$($K8S_CLI_BIN -n "$namespace" get daemonset netobserv-cli -o jsonpath="{.status.desiredNumberScheduled}")
         reasons=$($K8S_CLI_BIN get pods -n "$namespace" -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}')
         IFS=" " read -r -a reasons <<< "$(echo "${reasons[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
-        echo "$ready/$required Ready. Reason(s): $reasons"
+        echo "$ready/$required Ready. Reason(s): ${reasons[*]}"
         if printf '%s\0' "${reasons[@]}" | grep -Fxqz -- 'CrashLoopBackOff'; then
           break
         elif [[ $ready -eq $required ]]; then


### PR DESCRIPTION
## Description

The eBPF agent errors at startup will be displayed in CLI.
Example on OCP 4.15 with latest eBPF agent on packet capture (unsupported kernel):
```
Checking dependencies... 
'yq' is up to date (version v4.45.1).
'bash' is up to date (version v5.2.37).
Setting up... 
kube:admin
creating netobserv-cli namespace
namespace/netobserv-cli created
creating service account
serviceaccount/netobserv-cli created
clusterrole.rbac.authorization.k8s.io/netobserv-cli unchanged
clusterrolebinding.rbac.authorization.k8s.io/netobserv-cli unchanged
creating collector service
service/collector created
creating packet-capture agents
opt: filter_protocol, value: TCP
daemonset.apps/netobserv-cli created
Waiting for daemonset pods to be ready...
0/3 Ready. Reason(s): CrashLoopBackOff

ERROR: Daemonset pods failed to start:
Found 3 pods, using pod/netobserv-cli-d7vqz
time="2025-09-01T16:55:28Z" level=fatal msg="[PCA] can't instantiate NetObserv eBPF Agent" error="loading and assigning BPF objects: field TcEgressPcaParse: program tc_egress_pca_parse: load program: permission denied: invalid access to memory, mem_size=272 off=16 size=0: R3 min value is outside of the allowed memory range (514 line(s) omitted)"

kube:admin
Copy skipped

Cleaning up...
Deleting service monitor... 
Deleting dashboard configmap... 
Deleting daemonset... daemonset.apps "netobserv-cli" deleted

Deleting pod... 
Deleting namespace... namespace "netobserv-cli" deleted
```

Since the error from eBPF agent may be not very explicit, I have added a check per OCP version (when available):
```
Checking dependencies... 
'yq' is up to date (version v4.45.1).
'bash' is up to date (version v5.2.37).
Setting up... 
cluster-admin
OpenShift version: 4.12.0
- Network events requires OpenShift 4.19 or higher
- UDN mapping requires OpenShift 4.18 or higher
- Packet drops requires OpenShift 4.14 or higher
Remove not compatible features and try again
cluster-admin
Copy skipped

Cleaning up...
Deleting service monitor... 
Deleting dashboard configmap... 
Deleting daemonset... 
Deleting pod... 
Deleting namespace...
```

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
