### PR TITLE
NETOBSERV-2397 QE: Automate test for auto-detect privilege run feature in network observability CLI

### DIFF
--- a/e2e/integration-tests/integration_test.go
+++ b/e2e/integration-tests/integration_test.go
@@ -255,8 +255,6 @@ var _ = g.Describe("NetObserv CLI e2e integration test suite", g.Ordered, func()
 				cliArgs: []string{"flows", "--drops"},
 				matcher: o.BeTrue(),
 			},
-
-
 		}
 
 		for _, t := range tests {


### PR DESCRIPTION
## Description

Adds tests to verify correct privilege settings as introduced in: [NETOBSERV-2262](https://issues.redhat.com//browse/NETOBSERV-2262) 


Please also verify that polarion test case is created correctly: https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-84801) is created correctly.
## Dependencies

n/a
#
## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [x] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [x] If so, make sure it is described in the JIRA ticket.
    * polarion test case needs to be also verified, follow link in the description above 
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
