### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for network-observability-cli-zstream

### DIFF
--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -53,7 +53,8 @@ USER 65532:65532
 ENTRYPOINT ["/network-observability-cli"]
 
 LABEL com.redhat.component="network-observability-cli"
-LABEL name="network-observability-cli"
+LABEL name="network-observability/network-observability-cli-rhel9"
+LABEL cpe="cpe:/a:redhat:network_observ_optr:1.9::el9"
 LABEL io.k8s.display-name="Network Observability CLI"
 LABEL io.k8s.description="Network Observability CLI"
 LABEL summary="Network Observability CLI"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
