### PR TITLE
NETOBSERV-2435 fix background mode and update doc

### DIFF
--- a/cmd/display.go
+++ b/cmd/display.go
@@ -179,6 +179,25 @@ func hearbeat() {
 	}
 }
 
+func backgroundHearbeat() {
+	for {
+		if captureEnded {
+			return
+		}
+
+		if capture != Metric {
+			updateTableAndSuggestions()
+			// simply print flow into logs
+			rows := getTableRows()
+			for _, row := range rows {
+				log.Println(row)
+			}
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+}
+
 func pause(pause bool) {
 	paused = pause
 	playPauseButton.SetLabel(getPlayPauseText())

--- a/cmd/flow_capture.go
+++ b/cmd/flow_capture.go
@@ -24,8 +24,14 @@ var flowCmd = &cobra.Command{
 
 func runFlowCapture(_ *cobra.Command, _ []string) {
 	capture = Flow
-	go startFlowCollector()
-	createFlowDisplay()
+	showCount = defaultFlowShowCount
+	if isBackground {
+		go backgroundHearbeat() // show table periodically in background
+		startFlowCollector()
+	} else {
+		go startFlowCollector()
+		createFlowDisplay()
+	}
 }
 
 func startFlowCollector() {

--- a/cmd/metric_display.go
+++ b/cmd/metric_display.go
@@ -66,7 +66,6 @@ var (
 
 func createMetricDisplay() {
 	updateShowMetricCount()
-	updateGraphs(false)
 
 	app = tview.NewApplication().
 		SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {

--- a/cmd/packet_capture.go
+++ b/cmd/packet_capture.go
@@ -35,8 +35,13 @@ var (
 
 func runPacketCapture(_ *cobra.Command, _ []string) {
 	capture = Packet
-	go startPacketCollector()
-	createFlowDisplay()
+	if isBackground {
+		go backgroundHearbeat() // show table periodically in background
+		startPacketCollector()
+	} else {
+		go startPacketCollector()
+		createFlowDisplay()
+	}
 }
 
 //nolint:cyclop

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ var (
 	captureEnded     = false
 	stopReceived     = false
 	useMocks         = false
+	isBackground     = false
 )
 
 // Execute executes the root command.
@@ -102,7 +103,10 @@ func onInit() {
 	printBanner()
 
 	log.Infof("Log level: %s\nOption(s): %s", logLevel, options)
-
+	if strings.Contains(options, "background") && !strings.Contains(options, "background=false") {
+		isBackground = true
+		log.Infof("Running in background mode")
+	}
 	showKernelVersion()
 
 	if useMocks {
@@ -143,7 +147,7 @@ func onLimitReached() bool {
 		if app != nil && errAdvancedDisplay == nil {
 			app.Stop()
 		}
-		if strings.Contains(options, "background=true") {
+		if isBackground {
 			out, err := exec.Command("/oc-netobserv", "stop").Output()
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,23 +94,6 @@ func setup(t *testing.T) {
 	assert.Equal(t, nil, err)
 }
 
-func getTableRows() []string {
-	arr := []string{}
-	if len(tableData.cols) == 0 || len(tableData.flows) == 0 {
-		return arr
-	}
-
-	for i := range len(tableData.flows) + 1 {
-		str := ""
-		for j := range tableData.cols {
-			str += tableData.GetCell(i, j).Text
-		}
-		arr = append(arr, str)
-	}
-
-	return arr
-}
-
 func resetTime() {
 	// set timezone to Paris time for all tests
 	loc, err := time.LoadLocation("Europe/Paris")

--- a/docs/netobserv_cli.adoc
+++ b/docs/netobserv_cli.adoc
@@ -64,6 +64,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--enable_rtt|                enable RTT tracking                                   | false
 |--enable_udn_mapping|        enable User Defined Network mapping                   | false
 |--get-subnets|               get subnets information                               | false
+|--privileged|                force eBPF agent privileged mode                      | auto
 |--sampling|                  packets sampling interval                             | 1
 |--background|                run in background                                     | false
 |--copy|                      copy the output files locally                         | prompt
@@ -167,7 +168,10 @@ $ oc netobserv metrics [<option>]
 |--enable_rtt|                enable RTT tracking                                   | false
 |--enable_udn_mapping|        enable User Defined Network mapping                   | false
 |--get-subnets|               get subnets information                               | false
+|--privileged|                force eBPF agent privileged mode                      | auto
 |--sampling|                  packets sampling interval                             | 1
+|--background|                run in background                                     | false
+|--log-level|                 components logs                                       | info
 |--max-time|                  maximum capture time                                  | 1h
 |--action|                    filter action                                         | Accept
 |--cidr|                      filter CIDR                                           | 0.0.0.0/0

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -57,6 +57,11 @@ function help {
   echo "    --drops                                                   # including drops"
   echo "    --include_list=node,namespace                             # for all metrics matching 'node' or 'namespace' keywords"
   echo
+  echo "  Capture metrics in background"
+  echo "    netobserv metrics --background \                          # Capture metrics using background mode"
+  echo "    --max-time=24h                                            # for a maximum of 24 hours"
+  echo "  Then open the URL provided by the command to visualize the netobserv-cli dashboard anytime during or after the run."
+  echo
 }
 
 # display version
@@ -90,6 +95,8 @@ function flowsAndPackets_collector_usage {
 
 # fmetrics collector options
 function metrics_collector_usage {
+  echo "  --background:                 run in background                                     (default: false)"
+  echo "  --log-level:                  components logs                                       (default: info)"
   echo "  --max-time:                   maximum capture time                                  (default: 1h)"
 }
 


### PR DESCRIPTION
## Description

- Fix background mode issue (follow is not showing logs since the new UI was implemented)
- Update doc to add an example for metrics background


Example after running `$ oc netobserv metrics --background`:
```
$ oc netobserv follow
Checking dependencies... 
'yq' is up to date (version v4.45.1).
'bash' is up to date (version v5.2.37).
Starting network-observability-cli:
=====
Build version: unknown
Build date: unknown


------------------------------------------------------------------------
         _  _     _       _                       ___ _    ___
        | \| |___| |_ ___| |__ ___ ___ _ ___ __  / __| |  |_ _|
        | .' / -_)  _/ _ \ '_ (_-</ -_) '_\ V / | (__| |__ | | 
        |_|\_\___|\__\___/_.__/__/\___|_|  \_/   \___|____|___|

------------------------------------------------------------------------
time="2025-10-02T11:08:33Z" level=info msg="Log level: info\nOption(s): background"
time="2025-10-02T11:08:33Z" level=info msg="Running in background mode"
time="2025-10-02T11:08:33Z" level=info msg="Kernel version: 5.14.0-570.45.1.el9_6.x86_64"
time="2025-10-02T11:08:33Z" level=info msg="sum(rate(on_demand_netobserv_node_egress_bytes_total[2m]))"
time="2025-10-02T11:08:33Z" level=info msg="  No result"
time="2025-10-02T11:08:33Z" level=info msg="sum(rate(on_demand_netobserv_node_egress_packets_total[2m]))"
time="2025-10-02T11:08:33Z" level=info msg="  No result"
...
time="2025-10-02T11:10:03Z" level=info msg="sum(rate(on_demand_netobserv_node_egress_bytes_total[2m]))"
time="2025-10-02T11:10:03Z" level=info msg="  {} =>\n171675.09052430323 @[1759403100]"
time="2025-10-02T11:10:03Z" level=info msg="sum(rate(on_demand_netobserv_node_egress_packets_total[2m]))"
time="2025-10-02T11:10:03Z" level=info msg="  No result"
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
